### PR TITLE
fix: always ensure that query parameters are properly encoded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@commitlint/cli": "^13.1.0",
         "@commitlint/config-conventional": "^13.1.0",
         "@readme/eslint-config": "^6.0.0",
+        "@readme/oas-to-snippet": "^13.6.2",
         "datauri": "^4.1.0",
         "eslint": "^7.32.0",
         "husky": "^7.0.1",
@@ -2594,6 +2595,36 @@
         "prettier": "^2.0.2"
       }
     },
+    "node_modules/@readme/httpsnippet": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.5.1.tgz",
+      "integrity": "sha512-FyvsCWDcyDvBgy6Fb3RvHEWZIqWMdwjvBI7j4r0BnuOHfCuwJdL6h3YMZcJsA1h3IOQMUDd0gLIMmZsNPykwSQ==",
+      "dev": true,
+      "dependencies": {
+        "event-stream": "4.0.1",
+        "form-data": "3.0.0",
+        "har-validator": "^5.0.0",
+        "qs": "^6.9.6",
+        "stringify-object": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@readme/httpsnippet/node_modules/form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@readme/oas-extensions": {
       "version": "13.6.1",
       "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-13.6.1.tgz",
@@ -2601,6 +2632,73 @@
       "engines": {
         "node": "^12 || ^14 || ^16",
         "npm": "^7"
+      }
+    },
+    "node_modules/@readme/oas-to-har": {
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.6.1.tgz",
+      "integrity": "sha512-af56xwomcTw//LyXSu67sNcYTMwptjEITrbySDHltFrbhRx6gY/1zvniXJJm4nrQ/yam9vqCoH+dIOwpjbbSuQ==",
+      "dev": true,
+      "dependencies": {
+        "@readme/oas-extensions": "^13.6.0",
+        "oas": "^14.0.0",
+        "parse-data-url": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || ^16",
+        "npm": "^7"
+      }
+    },
+    "node_modules/@readme/oas-to-snippet": {
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-13.6.2.tgz",
+      "integrity": "sha512-1X+LsPA+hT6pO6GNeq2tdXjv4O1Q316XPmpQVg+zv5e65fY/Dk6m+7Scxf0eAWkvUf0ZRU32d+4XBj2HNh5Aew==",
+      "dev": true,
+      "dependencies": {
+        "@readme/httpsnippet": "^2.5.1",
+        "@readme/oas-extensions": "^13.6.0",
+        "@readme/oas-to-har": "^13.6.0",
+        "@readme/syntax-highlighter": "^10.10.1",
+        "httpsnippet-client-api": "^3.3.0",
+        "oas": "^14.0.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || ^16",
+        "npm": "^7"
+      }
+    },
+    "node_modules/@readme/syntax-highlighter": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.11.1.tgz",
+      "integrity": "sha512-oxmGrE5w7tzvNUFh2Min0EWkvMA/m7qYcsW0QuMvw/qC4HyLL0Txbmdhe9iaWOGSlup/gwlJO3dgMw50Z9cejw==",
+      "dev": true,
+      "dependencies": {
+        "codemirror": "^5.48.2",
+        "prop-types": "^15.7.2",
+        "react-codemirror2": "^7.2.1"
+      },
+      "peerDependencies": {
+        "@readme/variable": "*",
+        "react": "16.x",
+        "react-dom": "16.x"
+      }
+    },
+    "node_modules/@readme/variable": {
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-13.5.3.tgz",
+      "integrity": "sha512-/GP4Mfc9kEm9zy9CptAbonJ6vZ1HwrVjOD/Q7cDudCVumUiJ27y4k7DjLfykUTuDxtALhyz0c+4o0MA6+v9Q9A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "classnames": "^2.2.6",
+        "prop-types": "^15.7.2"
+      },
+      "engines": {
+        "node": "^12 || ^14 || ^16",
+        "npm": "^7"
+      },
+      "peerDependencies": {
+        "react": "16.x"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -3861,6 +3959,13 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "node_modules/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -3930,6 +4035,12 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
+    },
+    "node_modules/codemirror": {
+      "version": "5.62.3",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.3.tgz",
+      "integrity": "sha512-zZAyOfN8TU67ngqrxhOgtkSAGV9jSpN1snbl8elPtnh9Z5A11daR405+dhLzLnuXrwX0WCShWlybxPN3QC/9Pg==",
+      "dev": true
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -4043,6 +4154,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/conventional-changelog-angular": {
@@ -4413,6 +4533,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.3.768",
@@ -5611,6 +5737,21 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -5937,6 +6078,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
     "node_modules/fs-extra": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -6018,6 +6165,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
@@ -6331,6 +6484,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/httpsnippet-client-api": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-3.3.2.tgz",
+      "integrity": "sha512-AIU4DD8UXf95OTAgbSuoolxDNLrKlQ9oJOo4jjlloZR16Zf6i5xDtnKqeO2t3J8zuSuHXJl8f2fyr5u07k0bug==",
+      "dev": true,
+      "dependencies": {
+        "content-type": "^1.0.4",
+        "path-to-regexp": "^6.1.0",
+        "stringify-object": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12 || ^14 || ^16"
+      },
+      "peerDependencies": {
+        "@readme/httpsnippet": "^2.4.4",
+        "oas": "^14.0.0"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -6890,6 +7061,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-set": {
@@ -10752,6 +10932,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+      "dev": true
+    },
     "node_modules/memoizee": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
@@ -11717,6 +11903,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -11932,6 +12127,21 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/qs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -11954,6 +12164,47 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
       "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
+    },
+    "node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-codemirror2": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
+      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw==",
+      "dev": true,
+      "peerDependencies": {
+        "codemirror": "5.x",
+        "react": ">=15.5 <=16.x"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -12255,6 +12506,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -12466,6 +12728,18 @@
       "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
       "dev": true
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -12500,6 +12774,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "dev": true,
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "node_modules/string_decoder": {
@@ -12573,6 +12857,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/stringify-object/node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-ansi": {
@@ -15409,10 +15716,83 @@
         "eslint-plugin-unicorn": "^34.0.1"
       }
     },
+    "@readme/httpsnippet": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@readme/httpsnippet/-/httpsnippet-2.5.1.tgz",
+      "integrity": "sha512-FyvsCWDcyDvBgy6Fb3RvHEWZIqWMdwjvBI7j4r0BnuOHfCuwJdL6h3YMZcJsA1h3IOQMUDd0gLIMmZsNPykwSQ==",
+      "dev": true,
+      "requires": {
+        "event-stream": "4.0.1",
+        "form-data": "3.0.0",
+        "har-validator": "^5.0.0",
+        "qs": "^6.9.6",
+        "stringify-object": "^3.3.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@readme/oas-extensions": {
       "version": "13.6.1",
       "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-13.6.1.tgz",
       "integrity": "sha512-mDgYdpECIxiI+54lWmm5iZB+4QigRGrNS0BAkuRoINF2T1Qbenl8dKMjIy1JGIm7MG4xnWfXv8t5kh1imWv+2Q=="
+    },
+    "@readme/oas-to-har": {
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-har/-/oas-to-har-13.6.1.tgz",
+      "integrity": "sha512-af56xwomcTw//LyXSu67sNcYTMwptjEITrbySDHltFrbhRx6gY/1zvniXJJm4nrQ/yam9vqCoH+dIOwpjbbSuQ==",
+      "dev": true,
+      "requires": {
+        "@readme/oas-extensions": "^13.6.0",
+        "oas": "^14.0.0",
+        "parse-data-url": "^4.0.1"
+      }
+    },
+    "@readme/oas-to-snippet": {
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-13.6.2.tgz",
+      "integrity": "sha512-1X+LsPA+hT6pO6GNeq2tdXjv4O1Q316XPmpQVg+zv5e65fY/Dk6m+7Scxf0eAWkvUf0ZRU32d+4XBj2HNh5Aew==",
+      "dev": true,
+      "requires": {
+        "@readme/httpsnippet": "^2.5.1",
+        "@readme/oas-extensions": "^13.6.0",
+        "@readme/oas-to-har": "^13.6.0",
+        "@readme/syntax-highlighter": "^10.10.1",
+        "httpsnippet-client-api": "^3.3.0",
+        "oas": "^14.0.0"
+      }
+    },
+    "@readme/syntax-highlighter": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.11.1.tgz",
+      "integrity": "sha512-oxmGrE5w7tzvNUFh2Min0EWkvMA/m7qYcsW0QuMvw/qC4HyLL0Txbmdhe9iaWOGSlup/gwlJO3dgMw50Z9cejw==",
+      "dev": true,
+      "requires": {
+        "codemirror": "^5.48.2",
+        "prop-types": "^15.7.2",
+        "react-codemirror2": "^7.2.1"
+      }
+    },
+    "@readme/variable": {
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-13.5.3.tgz",
+      "integrity": "sha512-/GP4Mfc9kEm9zy9CptAbonJ6vZ1HwrVjOD/Q7cDudCVumUiJ27y4k7DjLfykUTuDxtALhyz0c+4o0MA6+v9Q9A==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "classnames": "^2.2.6",
+        "prop-types": "^15.7.2"
+      }
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -16355,6 +16735,13 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
+      "dev": true,
+      "peer": true
+    },
     "clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -16401,6 +16788,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "codemirror": {
+      "version": "5.62.3",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.3.tgz",
+      "integrity": "sha512-zZAyOfN8TU67ngqrxhOgtkSAGV9jSpN1snbl8elPtnh9Z5A11daR405+dhLzLnuXrwX0WCShWlybxPN3QC/9Pg==",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -16503,6 +16896,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "conventional-changelog-angular": {
@@ -16807,6 +17206,12 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "electron-to-chromium": {
       "version": "1.3.768",
@@ -17723,6 +18128,21 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -17986,6 +18406,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
     "fs-extra": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -18045,6 +18471,12 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -18267,6 +18699,17 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
+      }
+    },
+    "httpsnippet-client-api": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/httpsnippet-client-api/-/httpsnippet-client-api-3.3.2.tgz",
+      "integrity": "sha512-AIU4DD8UXf95OTAgbSuoolxDNLrKlQ9oJOo4jjlloZR16Zf6i5xDtnKqeO2t3J8zuSuHXJl8f2fyr5u07k0bug==",
+      "dev": true,
+      "requires": {
+        "content-type": "^1.0.4",
+        "path-to-regexp": "^6.1.0",
+        "stringify-object": "^3.3.0"
       }
     },
     "human-signals": {
@@ -18649,6 +19092,12 @@
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.2"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
     },
     "is-set": {
       "version": "2.0.2",
@@ -21618,6 +22067,12 @@
       "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
       "dev": true
     },
+    "map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+      "dev": true
+    },
     "memoizee": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
@@ -22359,6 +22814,15 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -22518,6 +22982,15 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
+    "qs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "dev": true,
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
+    },
     "queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -22537,6 +23010,38 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
       "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
+    },
+    "react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-codemirror2": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
+      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw==",
+      "dev": true,
+      "requires": {}
+    },
+    "react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      }
     },
     "react-is": {
       "version": "16.13.1",
@@ -22775,6 +23280,17 @@
         "xmlchars": "^2.2.0"
       }
     },
+    "scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -22963,6 +23479,15 @@
       "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -22993,6 +23518,16 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
+      }
+    },
+    "stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "string_decoder": {
@@ -23054,6 +23589,25 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      }
+    },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "dependencies": {
+        "is-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+          "dev": true
+        }
       }
     },
     "strip-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@commitlint/cli": "^13.1.0",
         "@commitlint/config-conventional": "^13.1.0",
         "@readme/eslint-config": "^6.0.0",
-        "@readme/oas-to-snippet": "^13.6.2",
+        "@readme/oas-to-snippet": "^14.0.0",
         "datauri": "^4.1.0",
         "eslint": "^7.32.0",
         "husky": "^7.0.1",
@@ -2650,55 +2650,20 @@
       }
     },
     "node_modules/@readme/oas-to-snippet": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-13.6.2.tgz",
-      "integrity": "sha512-1X+LsPA+hT6pO6GNeq2tdXjv4O1Q316XPmpQVg+zv5e65fY/Dk6m+7Scxf0eAWkvUf0ZRU32d+4XBj2HNh5Aew==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-14.0.0.tgz",
+      "integrity": "sha512-l159093GdlCz1afWGpv0mn6tgaVE+lQq/Kiy0aKd8iGgvhIyA6GQOtSdCBhIVV5GCV6tQWArEUNuKiLIvYHwGw==",
       "dev": true,
       "dependencies": {
         "@readme/httpsnippet": "^2.5.1",
         "@readme/oas-extensions": "^13.6.0",
         "@readme/oas-to-har": "^13.6.0",
-        "@readme/syntax-highlighter": "^10.10.1",
-        "httpsnippet-client-api": "^3.3.0",
+        "httpsnippet-client-api": "^3.3.2",
         "oas": "^14.0.0"
       },
       "engines": {
         "node": "^12 || ^14 || ^16",
         "npm": "^7"
-      }
-    },
-    "node_modules/@readme/syntax-highlighter": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.11.1.tgz",
-      "integrity": "sha512-oxmGrE5w7tzvNUFh2Min0EWkvMA/m7qYcsW0QuMvw/qC4HyLL0Txbmdhe9iaWOGSlup/gwlJO3dgMw50Z9cejw==",
-      "dev": true,
-      "dependencies": {
-        "codemirror": "^5.48.2",
-        "prop-types": "^15.7.2",
-        "react-codemirror2": "^7.2.1"
-      },
-      "peerDependencies": {
-        "@readme/variable": "*",
-        "react": "16.x",
-        "react-dom": "16.x"
-      }
-    },
-    "node_modules/@readme/variable": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-13.5.3.tgz",
-      "integrity": "sha512-/GP4Mfc9kEm9zy9CptAbonJ6vZ1HwrVjOD/Q7cDudCVumUiJ27y4k7DjLfykUTuDxtALhyz0c+4o0MA6+v9Q9A==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2"
-      },
-      "engines": {
-        "node": "^12 || ^14 || ^16",
-        "npm": "^7"
-      },
-      "peerDependencies": {
-        "react": "16.x"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -3959,13 +3924,6 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
-    "node_modules/classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -4035,12 +3993,6 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
-    },
-    "node_modules/codemirror": {
-      "version": "5.62.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.3.tgz",
-      "integrity": "sha512-zZAyOfN8TU67ngqrxhOgtkSAGV9jSpN1snbl8elPtnh9Z5A11daR405+dhLzLnuXrwX0WCShWlybxPN3QC/9Pg==",
-      "dev": true
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -12165,47 +12117,6 @@
       "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
       "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
     },
-    "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-codemirror2": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
-      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw==",
-      "dev": true,
-      "peerDependencies": {
-        "codemirror": "5.x",
-        "react": ">=15.5 <=16.x"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -12504,17 +12415,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "node_modules/semver": {
@@ -15759,39 +15659,16 @@
       }
     },
     "@readme/oas-to-snippet": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-13.6.2.tgz",
-      "integrity": "sha512-1X+LsPA+hT6pO6GNeq2tdXjv4O1Q316XPmpQVg+zv5e65fY/Dk6m+7Scxf0eAWkvUf0ZRU32d+4XBj2HNh5Aew==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-to-snippet/-/oas-to-snippet-14.0.0.tgz",
+      "integrity": "sha512-l159093GdlCz1afWGpv0mn6tgaVE+lQq/Kiy0aKd8iGgvhIyA6GQOtSdCBhIVV5GCV6tQWArEUNuKiLIvYHwGw==",
       "dev": true,
       "requires": {
         "@readme/httpsnippet": "^2.5.1",
         "@readme/oas-extensions": "^13.6.0",
         "@readme/oas-to-har": "^13.6.0",
-        "@readme/syntax-highlighter": "^10.10.1",
-        "httpsnippet-client-api": "^3.3.0",
+        "httpsnippet-client-api": "^3.3.2",
         "oas": "^14.0.0"
-      }
-    },
-    "@readme/syntax-highlighter": {
-      "version": "10.11.1",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.11.1.tgz",
-      "integrity": "sha512-oxmGrE5w7tzvNUFh2Min0EWkvMA/m7qYcsW0QuMvw/qC4HyLL0Txbmdhe9iaWOGSlup/gwlJO3dgMw50Z9cejw==",
-      "dev": true,
-      "requires": {
-        "codemirror": "^5.48.2",
-        "prop-types": "^15.7.2",
-        "react-codemirror2": "^7.2.1"
-      }
-    },
-    "@readme/variable": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-13.5.3.tgz",
-      "integrity": "sha512-/GP4Mfc9kEm9zy9CptAbonJ6vZ1HwrVjOD/Q7cDudCVumUiJ27y4k7DjLfykUTuDxtALhyz0c+4o0MA6+v9Q9A==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "classnames": "^2.2.6",
-        "prop-types": "^15.7.2"
       }
     },
     "@sinonjs/commons": {
@@ -16735,13 +16612,6 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "dev": true,
-      "peer": true
-    },
     "clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -16788,12 +16658,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "codemirror": {
-      "version": "5.62.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.3.tgz",
-      "integrity": "sha512-zZAyOfN8TU67ngqrxhOgtkSAGV9jSpN1snbl8elPtnh9Z5A11daR405+dhLzLnuXrwX0WCShWlybxPN3QC/9Pg==",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -23011,38 +22875,6 @@
       "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
       "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
     },
-    "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-codemirror2": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
-      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw==",
-      "dev": true,
-      "requires": {}
-    },
-    "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -23278,17 +23110,6 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
-      }
-    },
-    "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
     "@readme/eslint-config": "^6.0.0",
+    "@readme/oas-to-snippet": "^13.6.2",
     "datauri": "^4.1.0",
     "eslint": "^7.32.0",
     "husky": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
     "@readme/eslint-config": "^6.0.0",
-    "@readme/oas-to-snippet": "^13.6.2",
+    "@readme/oas-to-snippet": "^14.0.0",
     "datauri": "^4.1.0",
     "eslint": "^7.32.0",
     "husky": "^7.0.1",


### PR DESCRIPTION
## 🧰 What's being changed?

So what happens right now if you supply a query parameter that has characters that should be encoded, and that parameter does not have serialization configured, it'll be inserted into the HAR and generate an API request that is 100% not what you want.

For example, the following example from [api](https://npm.im/api):

```js
const spec = {
  servers: [
    { url: 'https://httpbin.org' }
  ],
  paths: {
    '/anything': {
      get: {
        parameters: [
          { name: 'pound', in: 'query' },
          { name: 'hash', in: 'query' },
          { name: 'array', in: 'query' },
          { name: 'weird', in: 'query' },
        ],
      },
    },
  },
};

const sdk = require('./packages/api')(spec);

(async () => {
  await sdk.get('/anything', {
    pound: 'something&nothing=true',
    hash: 'hash#data',
    array: 'where[4]=10',
    weird: 'properties["$email"] == "testing"',
  }).then(res => {
    console.log(res)
  });
})();
```

The API SDK there will attempt to make a request to https://httpbin.org/anything?pound=something&nothing=true&hash=hash

Not only was `nothing=true` sent as its own parameter when it should have been apart of `something`, but `array` and `weird` were completely discarded because they ended up landing in the URL after `#data` in the `hash` parameter.

<img src="https://user-images.githubusercontent.com/33762/131766582-5c6bb50d-ea0f-4ba3-8f81-7587df16c756.png" width="100" />

This work does a few things:

* [x] Refactors our parameter formatter to run query parameters through `encodeURIComponent()` if they are not already encoded.
  * To determine if something is already encoded we run it through `decodeURIComponent()` and check if that matches the original. If it does it wasn't.
* [x] Slightly modifies our parameter serialization work to not run query parameters through form serialization if have already been run through `encodeURIComponent()`.
* [x] Added some integration tests with [oas-to-snippet](https://npm.im/@readme/oas-to-snippet) to ensure that there are no side effects as a result of us sending encoded query params into it.
* [x] Refactors the serialization tests a bit to remove some DRY code.

Fix in support of RM-1986.

## 🧬 Testing

I added a handful of tests that you can check out, but with this fix and the corresponding update in https://github.com/readmeio/api/pull/331 running the above `api` snippet will be the same as if you ran this:

```js
await sdk.get('/anything', {
  pound: encodeURIComponent('something&nothing=true'),
  hash: encodeURIComponent('hash#data'),
  array: encodeURIComponent('where[4]=10'),
  weird: encodeURIComponent('properties["$email"] == "testing"'),
}).then(res => {
  console.log(res)
});
```