### PR TITLE
fix: quirks with un-styled query parameters not always being encoded

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`parameters query URI encoding should encode query parameters 1`] = `
 "curl --request GET \\\\
-     --url 'https://httpbin.org/anything?stringPound=something%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item'"
+     --url 'https://httpbin.org/anything?stringPound=something%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item'"
 `;
 
 exports[`parameters query URI encoding should encode query parameters 2`] = `
 "const fetch = require('node-fetch');
 
-const url = 'https://httpbin.org/anything?stringPound=something%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item';
+const url = 'https://httpbin.org/anything?stringPound=something%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item';
 const options = {method: 'GET'};
 
 fetch(url, options)
@@ -25,7 +25,7 @@ sdk.get('/anything', {
   stringHash: 'hash%23data',
   stringArray: 'where%5B4%5D%3D10',
   stringWeird: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
-  array: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item'
+  array: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item'
 })
   .then(res => console.log(res))
   .catch(err => console.error(err));"

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parameters query URI encoding should encode query parameters 1`] = `
+"curl --request GET \\\\
+     --url 'https://httpbin.org/anything?stringPound=somethign%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item'"
+`;
+
+exports[`parameters query URI encoding should encode query parameters 2`] = `
+"const fetch = require('node-fetch');
+
+const url = 'https://httpbin.org/anything?stringPound=somethign%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item';
+const options = {method: 'GET'};
+
+fetch(url, options)
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error('error:' + err));"
+`;
+
+exports[`parameters query URI encoding should encode query parameters 3`] = `
+"const sdk = require('api')('https://example.com');
+
+sdk.get('/anything', {
+  stringPound: 'somethign%26nothing%3Dtrue',
+  stringHash: 'hash%23data',
+  stringArray: 'where%5B4%5D%3D10',
+  stringWeird: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
+  array: ['something%26nothing%3Dtrue', 'nothing%26something%3Dfalse', 'second%20item']
+})
+  .then(res => console.log(res))
+  .catch(err => console.error(err));"
+`;

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -25,7 +25,7 @@ sdk.get('/anything', {
   stringHash: 'hash%23data',
   stringArray: 'where%5B4%5D%3D10',
   stringWeird: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
-  array: ['something%26nothing%3Dtrue', 'nothing%26something%3Dfalse', 'second%20item']
+  array: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item'
 })
   .then(res => console.log(res))
   .catch(err => console.error(err));"

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`parameters query URI encoding should encode query parameters 1`] = `
 "curl --request GET \\\\
-     --url 'https://httpbin.org/anything?stringPound=somethign%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item'"
+     --url 'https://httpbin.org/anything?stringPound=something%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item'"
 `;
 
 exports[`parameters query URI encoding should encode query parameters 2`] = `
 "const fetch = require('node-fetch');
 
-const url = 'https://httpbin.org/anything?stringPound=somethign%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item';
+const url = 'https://httpbin.org/anything?stringPound=something%26nothing%3Dtrue&stringHash=hash%23data&stringArray=where%5B4%5D%3D10&stringWeird=properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22&array=something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item';
 const options = {method: 'GET'};
 
 fetch(url, options)
@@ -21,7 +21,7 @@ exports[`parameters query URI encoding should encode query parameters 3`] = `
 "const sdk = require('api')('https://example.com');
 
 sdk.get('/anything', {
-  stringPound: 'somethign%26nothing%3Dtrue',
+  stringPound: 'something%26nothing%3Dtrue',
   stringHash: 'hash%23data',
   stringArray: 'where%5B4%5D%3D10',
   stringWeird: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -323,7 +323,7 @@ describe('parameters', () => {
             array: [
               encodeURIComponent('something&nothing=true'), // This is already encoded so it shouldn't be double encoded.
               'nothing&something=false',
-              'second item',
+              'another item',
             ],
           },
         };
@@ -341,7 +341,7 @@ describe('parameters', () => {
             name: 'stringWeird',
             value: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
           },
-          { name: 'array', value: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item' },
+          { name: 'array', value: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item' },
         ]);
 
         // Run some integration tests with `@readme/oas-to-snippet` to ensure that URI encoding query params don't
@@ -366,7 +366,7 @@ describe('parameters', () => {
             array: [
               'something&nothing=true', // Should still encode this one eventhrough the others are already encoded.
               encodeURIComponent('nothing&something=false'),
-              encodeURIComponent('second item'),
+              encodeURIComponent('another item'),
             ],
           },
         };
@@ -384,7 +384,7 @@ describe('parameters', () => {
             name: 'stringWeird',
             value: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
           },
-          { name: 'array', value: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item' },
+          { name: 'array', value: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item' },
         ]);
       });
     });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -316,7 +316,7 @@ describe('parameters', () => {
       it('should encode query parameters', async () => {
         const formData = {
           query: {
-            stringPound: 'somethign&nothing=true',
+            stringPound: 'something&nothing=true',
             stringHash: 'hash#data',
             stringArray: 'where[4]=10',
             stringWeird: 'properties["$email"] == "testing"',
@@ -334,7 +334,7 @@ describe('parameters', () => {
         await expect(har).toBeAValidHAR();
 
         expect(har.log.entries[0].request.queryString).toStrictEqual([
-          { name: 'stringPound', value: 'somethign%26nothing%3Dtrue' },
+          { name: 'stringPound', value: 'something%26nothing%3Dtrue' },
           { name: 'stringHash', value: 'hash%23data' },
           { name: 'stringArray', value: 'where%5B4%5D%3D10' },
           {
@@ -359,7 +359,7 @@ describe('parameters', () => {
       it('should not double encode query parameters that are already encoded', async () => {
         const formData = {
           query: {
-            stringPound: encodeURIComponent('somethign&nothing=true'),
+            stringPound: encodeURIComponent('something&nothing=true'),
             stringHash: encodeURIComponent('hash#data'),
             stringArray: encodeURIComponent('where[4]=10'),
             stringWeird: encodeURIComponent('properties["$email"] == "testing"'),
@@ -377,7 +377,7 @@ describe('parameters', () => {
         await expect(har).toBeAValidHAR();
 
         expect(har.log.entries[0].request.queryString).toStrictEqual([
-          { name: 'stringPound', value: 'somethign%26nothing%3Dtrue' },
+          { name: 'stringPound', value: 'something%26nothing%3Dtrue' },
           { name: 'stringHash', value: 'hash%23data' },
           { name: 'stringArray', value: 'where%5B4%5D%3D10' },
           {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -248,10 +248,7 @@ describe('parameters', () => {
           parameters: [{ name: 'id', in: 'query' }],
         },
         { query: { id: [null, null] } },
-        [
-          { name: 'id', value: 'null' },
-          { name: 'id', value: 'null' },
-        ],
+        [{ name: 'id', value: '&id=' }],
       ],
       [
         'should handle null values',
@@ -280,10 +277,7 @@ describe('parameters', () => {
           ],
         },
         { query: {} },
-        [
-          { name: 'id', value: 'null' },
-          { name: 'id', value: 'null' },
-        ],
+        [{ name: 'id', value: '&id=' }],
       ],
     ])('%s', async (_, operation = {}, formData = {}, expectedQueryString = []) => {
       const har = oasToHar(
@@ -347,9 +341,7 @@ describe('parameters', () => {
             name: 'stringWeird',
             value: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
           },
-          { name: 'array', value: 'something%26nothing%3Dtrue' },
-          { name: 'array', value: 'nothing%26something%3Dfalse' },
-          { name: 'array', value: 'second%20item' },
+          { name: 'array', value: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item' },
         ]);
 
         // Run some integration tests with `@readme/oas-to-snippet` to ensure that URI encoding query params don't
@@ -392,9 +384,7 @@ describe('parameters', () => {
             name: 'stringWeird',
             value: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
           },
-          { name: 'array', value: 'something%26nothing%3Dtrue' },
-          { name: 'array', value: 'nothing%26something%3Dfalse' },
-          { name: 'array', value: 'second%20item' },
+          { name: 'array', value: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=second%20item' },
         ]);
       });
     });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -321,7 +321,7 @@ describe('parameters', () => {
             stringArray: 'where[4]=10',
             stringWeird: 'properties["$email"] == "testing"',
             array: [
-              encodeURI('something&nothing=true'), // This is already encoded so it shouldn't be double encoded.
+              encodeURIComponent('something&nothing=true'), // This is already encoded so it shouldn't be double encoded.
               'nothing&something=false',
               'second item',
             ],

--- a/__tests__/lib/style-formatting/index.test.js
+++ b/__tests__/lib/style-formatting/index.test.js
@@ -7,10 +7,10 @@ const undefinedInput = undefined;
 const stringInput = 'blue';
 const stringInputEncoded = encodeURIComponent('something&nothing=true');
 const arrayInput = ['blue', 'black', 'brown'];
-const arrayInputEncoded = ['somethign&nothing=true', 'hash#data'];
+const arrayInputEncoded = ['something&nothing=true', 'hash#data'];
 const undefinedArrayInput = [undefined];
 const objectInput = { R: 100, G: 200, B: 150 };
-const objectInputEncoded = { pound: 'somethign&nothing=true', hash: 'hash#data' };
+const objectInputEncoded = { pound: 'something&nothing=true', hash: 'hash#data' };
 const undefinedObjectInput = { R: undefined };
 
 const semicolon = ';'; // %3B when encoded, which we don't want
@@ -426,7 +426,7 @@ describe('query parameters', () => {
         'should support form delimited query styles for non exploded array input and NOT encode already encoded values',
         paramNoExplode,
         { query: { color: arrayInputEncoded } },
-        [{ name: 'color', value: 'somethign%26nothing%3Dtrue,hash%23data' }],
+        [{ name: 'color', value: 'something%26nothing%3Dtrue,hash%23data' }],
       ],
       [
         'should support form delimited query styles for exploded array input',
@@ -443,7 +443,7 @@ describe('query parameters', () => {
         paramExplode,
         { query: { color: arrayInputEncoded } },
         [
-          { name: 'color', value: 'somethign%26nothing%3Dtrue' },
+          { name: 'color', value: 'something%26nothing%3Dtrue' },
           { name: 'color', value: 'hash%23data' },
         ],
       ],
@@ -457,7 +457,7 @@ describe('query parameters', () => {
         'should support form delimited query styles for non exploded object input and NOT encode already encoded values',
         paramNoExplode,
         { query: { color: objectInputEncoded } },
-        [{ name: 'color', value: 'pound,somethign%26nothing%3Dtrue,hash,hash%23data' }],
+        [{ name: 'color', value: 'pound,something%26nothing%3Dtrue,hash,hash%23data' }],
       ],
       [
         'should support form delimited query styles for exploded object input',
@@ -474,7 +474,7 @@ describe('query parameters', () => {
         paramExplode,
         { query: { color: objectInputEncoded } },
         [
-          { name: 'pound', value: 'somethign%26nothing%3Dtrue' },
+          { name: 'pound', value: 'something%26nothing%3Dtrue' },
           { name: 'hash', value: 'hash%23data' },
         ],
       ],
@@ -545,7 +545,7 @@ describe('query parameters', () => {
         'should support space delimited query styles for non exploded array input and NOT encode already encoded values',
         paramNoExplode,
         { query: { color: arrayInputEncoded } },
-        [{ name: 'color', value: 'somethign%26nothing%3Dtrue hash%23data' }],
+        [{ name: 'color', value: 'something%26nothing%3Dtrue hash%23data' }],
       ],
       [
         'should NOT support space delimited query styles for exploded array input',
@@ -634,7 +634,7 @@ describe('query parameters', () => {
         'should support pipe delimited query styles for non exploded array input and NOT encode already encoded values',
         paramNoExplode,
         { query: { color: arrayInputEncoded } },
-        [{ name: 'color', value: 'somethign%26nothing%3Dtrue|hash%23data' }],
+        [{ name: 'color', value: 'something%26nothing%3Dtrue|hash%23data' }],
       ],
       [
         'should NOT support pipe delimited query styles for exploded array input',
@@ -745,7 +745,7 @@ describe('query parameters', () => {
         paramExplode,
         { query: { color: objectInputEncoded } },
         [
-          { name: 'color[pound]', value: 'somethign%26nothing%3Dtrue' },
+          { name: 'color[pound]', value: 'something%26nothing%3Dtrue' },
           { name: 'color[hash]', value: 'hash%23data' },
         ],
       ],

--- a/__tests__/lib/style-formatting/index.test.js
+++ b/__tests__/lib/style-formatting/index.test.js
@@ -5,9 +5,12 @@ const oasToHar = require('../../../src/index');
 const emptyInput = '';
 const undefinedInput = undefined;
 const stringInput = 'blue';
+const stringInputEncoded = encodeURIComponent('something&nothing=true');
 const arrayInput = ['blue', 'black', 'brown'];
+const arrayInputEncoded = ['somethign&nothing=true', 'hash#data'];
 const undefinedArrayInput = [undefined];
 const objectInput = { R: 100, G: 200, B: 150 };
+const objectInputEncoded = { pound: 'somethign&nothing=true', hash: 'hash#data' };
 const undefinedObjectInput = { R: undefined };
 
 const semicolon = ';'; // %3B when encoded, which we don't want
@@ -71,7 +74,6 @@ function createOas(path, operation) {
  *  deepObject      true      n/a     n/a           n/a                                   color[R]=100&color[G]=200&color[B]=150  query
  */
 
-// This should work for matrix(empty, primitive, array, object)*(explode:t/f), label(empty, primitive, array, object)*(explode:t/f), simple(primitive, array, object)*(explode:t/f)
 describe('path parameters', () => {
   describe('matrix path', () => {
     const paramNoExplode = {
@@ -353,7 +355,6 @@ describe('path parameters', () => {
   });
 });
 
-// this should test form(empty, primitive, array, object)*(explode:t/f), spaceDelimited(array, object)*(explode:f), pipeDelimited(array, object)*(explode:f), deepObject(object)*(explode:t)
 describe('query parameters', () => {
   describe('form style', () => {
     const paramNoExplode = {
@@ -398,16 +399,34 @@ describe('query parameters', () => {
         [{ name: 'color', value: 'blue' }],
       ],
       [
+        'should support form delimited query styles for non exploded string input and NOT encode already encoded values',
+        paramNoExplode,
+        { query: { color: stringInputEncoded } },
+        [{ name: 'color', value: 'something%26nothing%3Dtrue' }],
+      ],
+      [
         'should support form delimited query styles for exploded string input',
         paramExplode,
         { query: { color: stringInput } },
         [{ name: 'color', value: 'blue' }],
       ],
       [
+        'should support form delimited query styles for exploded string input and NOT encode already encoded values',
+        paramExplode,
+        { query: { color: stringInputEncoded } },
+        [{ name: 'color', value: 'something%26nothing%3Dtrue' }],
+      ],
+      [
         'should support form delimited query styles for non exploded array input',
         paramNoExplode,
         { query: { color: arrayInput } },
         [{ name: 'color', value: 'blue,black,brown' }],
+      ],
+      [
+        'should support form delimited query styles for non exploded array input and NOT encode already encoded values',
+        paramNoExplode,
+        { query: { color: arrayInputEncoded } },
+        [{ name: 'color', value: 'somethign%26nothing%3Dtrue,hash%23data' }],
       ],
       [
         'should support form delimited query styles for exploded array input',
@@ -420,10 +439,25 @@ describe('query parameters', () => {
         ],
       ],
       [
+        'should support form delimited query styles for exploded array inpu and NOT encode already encoded values',
+        paramExplode,
+        { query: { color: arrayInputEncoded } },
+        [
+          { name: 'color', value: 'somethign%26nothing%3Dtrue' },
+          { name: 'color', value: 'hash%23data' },
+        ],
+      ],
+      [
         'should support form delimited query styles for non exploded object input',
         paramNoExplode,
         { query: { color: objectInput } },
         [{ name: 'color', value: 'R,100,G,200,B,150' }],
+      ],
+      [
+        'should support form delimited query styles for non exploded object input and NOT encode already encoded values',
+        paramNoExplode,
+        { query: { color: objectInputEncoded } },
+        [{ name: 'color', value: 'pound,somethign%26nothing%3Dtrue,hash,hash%23data' }],
       ],
       [
         'should support form delimited query styles for exploded object input',
@@ -436,16 +470,13 @@ describe('query parameters', () => {
         ],
       ],
       [
-        'should not encode already encoded values for non-exploded form delimited styles',
-        paramNoExplode,
-        { query: { color: encodeURIComponent(arrayInput) } },
-        [{ name: 'color', value: 'blue%2Cblack%2Cbrown' }],
-      ],
-      [
-        'should not encode already encoded values for exploded form delimited styles',
+        'should support form delimited query styles for exploded object input and NOT encode already encoded values',
         paramExplode,
-        { query: { color: encodeURIComponent(arrayInput) } },
-        [{ name: 'color', value: 'blue%2Cblack%2Cbrown' }],
+        { query: { color: objectInputEncoded } },
+        [
+          { name: 'pound', value: 'somethign%26nothing%3Dtrue' },
+          { name: 'hash', value: 'hash%23data' },
+        ],
       ],
     ])('%s', async (_, operation = {}, formData = {}, expectedQueryString = []) => {
       const oas = createOas('/query', operation);
@@ -508,8 +539,13 @@ describe('query parameters', () => {
         'should support space delimited query styles for non exploded array input',
         paramNoExplode,
         { query: { color: arrayInput } },
-        // Note: this is space here, but %20 in the example above, because encoding happens far down the line
         [{ name: 'color', value: 'blue black brown' }],
+      ],
+      [
+        'should support space delimited query styles for non exploded array input and NOT encode already encoded values',
+        paramNoExplode,
+        { query: { color: arrayInputEncoded } },
+        [{ name: 'color', value: 'somethign%26nothing%3Dtrue hash%23data' }],
       ],
       [
         'should NOT support space delimited query styles for exploded array input',
@@ -530,18 +566,6 @@ describe('query parameters', () => {
         paramExplode,
         { query: { color: objectInput } },
         [],
-      ],
-      [
-        'should not encode already encoded values for non-exploded spaceDelimited styles',
-        paramNoExplode,
-        { query: { color: encodeURIComponent(arrayInput) } },
-        [{ name: 'color', value: 'blue%2Cblack%2Cbrown' }],
-      ],
-      [
-        'should not encode already encoded values for exploded spaceDelimited styles',
-        paramExplode,
-        { query: { color: encodeURIComponent(arrayInput) } },
-        [{ name: 'color', value: 'blue%2Cblack%2Cbrown' }],
       ],
     ])('%s', async (_, operation = {}, formData = {}, expectedQueryString = []) => {
       const oas = createOas('/query', operation);
@@ -607,6 +631,12 @@ describe('query parameters', () => {
         [{ name: 'color', value: 'blue|black|brown' }],
       ],
       [
+        'should support pipe delimited query styles for non exploded array input and NOT encode already encoded values',
+        paramNoExplode,
+        { query: { color: arrayInputEncoded } },
+        [{ name: 'color', value: 'somethign%26nothing%3Dtrue|hash%23data' }],
+      ],
+      [
         'should NOT support pipe delimited query styles for exploded array input',
         paramExplode,
         { query: { color: arrayInput } },
@@ -624,18 +654,6 @@ describe('query parameters', () => {
         paramExplode,
         { query: { color: objectInput } },
         [],
-      ],
-      [
-        'should not encode already encoded values for non-exploded pipeDelimited styles',
-        paramNoExplode,
-        { query: { color: encodeURIComponent(arrayInput) } },
-        [{ name: 'color', value: 'blue%2Cblack%2Cbrown' }],
-      ],
-      [
-        'should not encode already encoded values for exploded pipeDelimited styles',
-        paramExplode,
-        { query: { color: encodeURIComponent(arrayInput) } },
-        [{ name: 'color', value: 'blue%2Cblack%2Cbrown' }],
       ],
     ])('%s', async (_, operation = {}, formData = {}, expectedQueryString = []) => {
       const oas = createOas('/query', operation);
@@ -723,16 +741,13 @@ describe('query parameters', () => {
         ],
       ],
       [
-        'should not encode already encoded values for non-exploded deepObject styles',
-        paramNoExplode,
-        { query: { color: encodeURIComponent(objectInput) } },
-        [{ name: 'color', value: '%5Bobject%20Object%5D' }],
-      ],
-      [
-        'should not encode already encoded values for exploded deepObject styles',
+        'should support deepObject delimited query styles for exploded object input and NOT encode already encoded values',
         paramExplode,
-        { query: { color: encodeURIComponent(objectInput) } },
-        [{ name: 'color', value: '%5Bobject%20Object%5D' }],
+        { query: { color: objectInputEncoded } },
+        [
+          { name: 'color[pound]', value: 'somethign%26nothing%3Dtrue' },
+          { name: 'color[hash]', value: 'hash%23data' },
+        ],
       ],
     ])('%s', async (_, operation = {}, formData = {}, expectedQueryString = []) => {
       const oas = createOas('/query', operation);
@@ -744,7 +759,6 @@ describe('query parameters', () => {
   });
 });
 
-// This should work for form style, supporting empty, string array and object inputs, with both exploded and non-exploded output
 describe('cookie parameters', () => {
   const paramNoExplode = {
     parameters: [
@@ -843,7 +857,6 @@ describe('cookie parameters', () => {
   });
 });
 
-// This should work for simple styles on arrays and objects, each with and without exploding. Everything else should return undefined.
 describe('header parameters', () => {
   const paramNoExplode = {
     parameters: [

--- a/src/index.js
+++ b/src/index.js
@@ -8,17 +8,9 @@ const configureSecurity = require('./lib/configure-security');
 const removeUndefinedObjects = require('./lib/remove-undefined-objects');
 const formatStyle = require('./lib/style-formatting');
 
-function isURIEncoded(str) {
-  return decodeURIComponent(str) !== str;
-}
-
 function formatter(values, param, type, onlyIfExists) {
   if (param.style) {
     const value = values[type][param.name];
-    if (type === 'query' && typeof value === 'string' && isURIEncoded(value)) {
-      return value;
-    }
-
     // Note: Technically we could send everything through the format style and choose the proper default for each
     //  `in` type (e.g. query defaults to form).
     return formatStyle(value, param);
@@ -39,8 +31,9 @@ function formatter(values, param, type, onlyIfExists) {
   }
 
   if (value !== undefined) {
-    if (type === 'query' && !isURIEncoded(value)) {
-      return encodeURIComponent(value);
+    // Query params should always be formatted, even if they don't have a `style` serialization configured.
+    if (type === 'query') {
+      return formatStyle(value, param);
     }
 
     return value;

--- a/src/lib/style-formatting/index.js
+++ b/src/lib/style-formatting/index.js
@@ -66,6 +66,7 @@ function stylizeValue(value, parameter) {
   }
 
   return stylize({
+    location: parameter.in,
     value: finalValue,
     key: parameter.name,
     style: parameter.style,

--- a/src/lib/style-formatting/index.js
+++ b/src/lib/style-formatting/index.js
@@ -65,12 +65,39 @@ function stylizeValue(value, parameter) {
     return value;
   }
 
+  // All parameter types have a default `style` format so if they don't have one prescribed we should still conform to
+  // what the spec defines.
+  //
+  // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#user-content-parameterstyle
+  // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#user-content-parameterstyle
+  let style = parameter.style;
+  if (!style) {
+    if (parameter.in === 'query') {
+      style = 'form';
+    } else if (parameter.in === 'path') {
+      style = 'simple';
+    } else if (parameter.in === 'header') {
+      style = 'simple';
+    } else if (parameter.in === 'cookie') {
+      style = 'form';
+    }
+  }
+
+  let explode = parameter.explode;
+  if (explode === undefined && style === 'form') {
+    // Per the spec if no `explode` is present but `style` is `form` then `explode` should default to `true`.
+    //
+    // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#user-content-parameterexplode
+    // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#user-content-parameterexplode
+    explode = true;
+  }
+
   return stylize({
     location: parameter.in,
     value: finalValue,
     key: parameter.name,
-    style: parameter.style,
-    explode: parameter.explode,
+    style,
+    explode,
     /*
       TODO: this parameter is optional to stylize. It defaults to false, and can accept falsy, truthy, or "unsafe".
       I do not know if it is correct for query to use this. See style-serializer for more info

--- a/src/lib/style-formatting/style-serializer.js
+++ b/src/lib/style-formatting/style-serializer.js
@@ -125,11 +125,6 @@ function encodeArray({ location, key, value, style, explode, escape }) {
     return value.map(val => valueEncoder(val)).join(`|${after}`);
   }
 
-  // If no style is present, query parameters should still **always** be encoded.
-  if (style === undefined && location === 'query') {
-    return value.map(val => valueEncoder(val));
-  }
-
   return undefined;
 }
 
@@ -224,11 +219,6 @@ function encodePrimitive({ location, key, value, style, escape }) {
 
   if (style === 'deepObject') {
     return valueEncoder(value, {}, true);
-  }
-
-  // If no style is present, query parameters should still **always** be encoded.
-  if (style === undefined && location === 'query') {
-    return valueEncoder(value);
   }
 
   return undefined;


### PR DESCRIPTION
## 🧰 What's being changed?

This refactors our handling of un-styled query parameters to always make sure that we encode, and don't double-encode, data where we support it.

Fix in support of RM-1986.

## 🧬 Testing

See tests.