### PR TITLE
fix: bug where query parameters with percent signs would crash the library

### DIFF
--- a/src/lib/style-formatting/style-serializer.js
+++ b/src/lib/style-formatting/style-serializer.js
@@ -18,7 +18,13 @@ const isRfc3986Reserved = char => ":/?#[]@!$&'()*+,;=".indexOf(char) > -1;
 const isRfc3986Unreserved = char => /^[a-z0-9\-._~]+$/i.test(char);
 
 function isURIEncoded(value) {
-  return decodeURIComponent(value) !== value;
+  try {
+    return decodeURIComponent(value) !== value;
+  } catch (err) {
+    // `decodeURIComponent` will throw an exception if a string that has an un-encoded percent sign in it (like 20%),
+    // so if it's throwing we can just assume that the value hasn't been encoded.
+    return false;
+  }
 }
 
 module.exports = function stylize(config) {


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a quirk in the new query parameter encoding work (#16, #17) where if a query parameter had an unencoded percent sign in it, the library would crash when attempting to determine if it was already encoded.

This will resolve the problem @Dashron found in https://github.com/readmeio/api/pull/331#issuecomment-912757432.

## 🧬 Testing

See tests.