### PR TITLE
feat: switch buffer to native Uint8Array

### DIFF
--- a/src/lib/style-formatting/style-serializer.js
+++ b/src/lib/style-formatting/style-serializer.js
@@ -12,8 +12,6 @@
  * @link https://github.com/swagger-api/swagger-js/blob/master/src/execute/oas3/style-serializer.js
  */
 
-const { Buffer } = require('buffer');
-
 const isRfc3986Reserved = char => ":/?#[]@!$&'()*+,;=".indexOf(char) > -1;
 const isRfc3986Unreserved = char => /^[a-z0-9\-._~]+$/i.test(char);
 
@@ -80,7 +78,8 @@ module.exports.encodeDisallowedCharacters = function encodeDisallowedCharacters(
         return char;
       }
 
-      const encoded = (Buffer.from(char).toJSON().data || [])
+      const encoder = new TextEncoder();
+      const encoded = Array.from(encoder.encode(char))
         .map(byte => `0${byte.toString(16).toUpperCase()}`.slice(-2))
         .map(encodedByte => `%${encodedByte}`)
         .join('');


### PR DESCRIPTION
## 🧰 What's being changed?

Since our `style-serializer` library is forked from `swagger-js` this pulls a recent change they made upstream in https://github.com/swagger-api/swagger-js/pull/2288 down to us.

## 🧬 Testing

Since `TextEncoder` doesn't exist in IE, Webpack will automatically polyfill that like it did with the Node `buffer` that we were pulling in. Main difference with this change is that that polyfill, and the resulting Webpack generated dist, will be much smaller now.

That said, if tests still pass here we're good.