### PR TITLE
feat: upgrading oas to v17

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,15 +1,19 @@
 const extensions = require('@readme/oas-extensions');
-const Oas = require('oas');
+const Oas = require('oas').default;
 const path = require('path');
 const datauri = require('datauri');
+const oasToHar = require('../src');
+const toBeAValidHAR = require('jest-expect-har').default;
 
-const oasToHar = require('../src/index');
+const petstore = require('@readme/oas-examples/3.0/json/petstore.json');
 const commonParameters = require('./__fixtures__/common-parameters.json');
 const multipartFormData = require('./__fixtures__/multipart-form-data.json');
 const multipartFormDataArrayOfFiles = require('./__fixtures__/multipart-form-data/array-of-files.json');
 const serverVariables = require('./__fixtures__/server-variables.json');
 
-const oas = new Oas();
+expect.extend({ toBeAValidHAR });
+
+const oas = new Oas({});
 
 test('should output a har object', async () => {
   const har = oasToHar(oas);
@@ -28,6 +32,32 @@ test('should output a har object', async () => {
             method: '',
             queryString: [],
             url: 'https://example.com',
+          },
+        },
+      ],
+    },
+  });
+});
+
+test('should accept an Operation instance as the operation schema', async () => {
+  const spec = new Oas(petstore);
+  const operation = spec.operation('/pet', 'post');
+  const har = oasToHar(spec, operation);
+
+  await expect(har).toBeAValidHAR();
+  expect(har).toStrictEqual({
+    log: {
+      entries: [
+        {
+          request: {
+            cookies: [],
+            headers: [{ name: 'Content-Type', value: 'application/json' }],
+            headersSize: 0,
+            queryString: [],
+            bodySize: 0,
+            method: 'POST',
+            url: 'http://petstore.swagger.io/v2/pet',
+            httpVersion: 'HTTP/1.1',
           },
         },
       ],

--- a/__tests__/lib/style-formatting/index.test.js
+++ b/__tests__/lib/style-formatting/index.test.js
@@ -1,6 +1,8 @@
-const Oas = require('oas');
+const Oas = require('oas').default;
+const oasToHar = require('../../../src');
+const toBeAValidHAR = require('jest-expect-har').default;
 
-const oasToHar = require('../../../src/index');
+expect.extend({ toBeAValidHAR });
 
 const emptyInput = '';
 const undefinedInput = undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,20 @@
       "version": "13.8.1",
       "license": "ISC",
       "dependencies": {
-        "@readme/oas-extensions": "^13.7.0",
-        "oas": "^16.0.3",
+        "@readme/oas-extensions": "^14.0.0",
+        "oas": "^17.1.0",
         "parse-data-url": "^4.0.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^14.1.0",
         "@commitlint/config-conventional": "^14.1.0",
         "@readme/eslint-config": "^7.2.2",
+        "@readme/oas-examples": "^4.3.2",
         "datauri": "^4.1.0",
         "eslint": "^7.32.0",
         "husky": "^7.0.4",
         "jest": "^27.3.1",
-        "jest-expect-har": "^2.0.2",
+        "jest-expect-har": "^3.0.0",
         "prettier": "^2.4.1"
       },
       "engines": {
@@ -70,11 +71,11 @@
       "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -398,11 +399,11 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -585,9 +586,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
+      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -2544,15 +2545,15 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.1.0.tgz",
-      "integrity": "sha512-z1kzTcXpfM3X3TJiRpPwUJjRxfHQz3GBgvIDK6+sUn6/6lv1hHMGljiwgL/ViCShp6PRNbgGPhRWJOiJDffwYw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.1.1.tgz",
+      "integrity": "sha512-3FmPBv2fYj2Qgvg8Qq3wEL7CxLPA6nwkVGafdEfS/85DIUx9z0iZcHu48no/l0HOk9PCKUDqpinN6bTtLxD0og==",
       "dependencies": {
-        "@babel/code-frame": "^7.15.8",
-        "@babel/runtime": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/runtime": "^7.16.0",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "leven": "^3.1.0"
       },
       "engines": {
@@ -2661,13 +2662,22 @@
         "prettier": "^2.0.2"
       }
     },
+    "node_modules/@readme/oas-examples": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
+      "integrity": "sha512-zEK4w0BtSc5f4To7LyFOyGdv/El2oOy/xbU3KW3kzmbH3P4ZFYAHpMrXViZYsKjUZJ5w8VGNJeVfTXVs89eZkA==",
+      "dev": true
+    },
     "node_modules/@readme/oas-extensions": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-13.7.0.tgz",
-      "integrity": "sha512-z+zSUfsz93puBOy4rITQSnwH3OBpv/6uJCntzAL1zY2hVKTSmN94Yj+wB3uqOez6YemLQTze0ujJbYpNPUnKcQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.0.tgz",
+      "integrity": "sha512-7CC5rcATBH0M2ZhHfX9RoHC8kSOcnKjvHXDb9gswUlLNQcLyRzg8ycQhSIJQna+6BSuHMZ79Den+Xw0z+P6Lpg==",
       "engines": {
         "node": "^12 || ^14 || ^16",
         "npm": "^7"
+      },
+      "peerDependencies": {
+        "oas": "^17.1.0"
       }
     },
     "node_modules/@readme/openapi-parser": {
@@ -2913,6 +2923,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -3515,15 +3531,15 @@
       }
     },
     "node_modules/array.prototype.map": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.3.tgz",
-      "integrity": "sha512-nNcb30v0wfDyIe26Yif3PcV1JXQp4zEeEfupG7L4SRjnD6HLbO5b2a7eVSba53bOx4YCHYMBHt+Fp4vYstneRA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.4.tgz",
+      "integrity": "sha512-Qds9QnX7A0qISY7JT5WuJO0NJPE9CMlC6JzHQfhpqAAQQzufVRoeH7EzUY5GcPTx72voG8LV/5eo+b8Qi8hmhA==",
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
+        "es-abstract": "^1.19.0",
         "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.5"
+        "is-string": "^1.0.7"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4059,9 +4075,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
-      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
       "engines": {
         "node": ">=6"
       },
@@ -4639,21 +4655,24 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.4.tgz",
-      "integrity": "sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-symbols": "^1.0.2",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.3",
+        "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.3",
-        "is-string": "^1.0.6",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -4669,16 +4688,16 @@
       }
     },
     "node_modules/es-aggregate-error": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.5.tgz",
-      "integrity": "sha512-lCJhahEBlzD0WnPEpFCWqjxm4DI4fzuq1PVxLfsGdHImCWSUhASlv+lrBX4Wc47g62SAO4+axBUfUMgJYIhilg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.7.tgz",
+      "integrity": "sha512-Zob/KUAOQUTvCzqgL2FEgtqNLPX5rYW3VhlldZ6La4W2mJUv3J8DmD0/sPxuD+kSAKF6nuceJ3uOSvCaaTLUyQ==",
       "dependencies": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
+        "es-abstract": "^1.19.0",
         "function-bind": "^1.1.1",
-        "functions-have-names": "^1.2.1",
-        "get-intrinsic": "^1.0.1",
-        "globalthis": "^1.0.1"
+        "functions-have-names": "^1.2.2",
+        "get-intrinsic": "^1.1.1",
+        "globalthis": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5986,11 +6005,11 @@
       }
     },
     "node_modules/ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
       "dependencies": {
-        "type": "^2.0.0"
+        "type": "^2.5.0"
       }
     },
     "node_modules/ext/node_modules/type": {
@@ -6254,6 +6273,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/git-raw-commits": {
@@ -6791,9 +6825,9 @@
       "dev": true
     },
     "node_modules/inquirer": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
-      "integrity": "sha512-DHLKJwLPNgkfwNmsuEUKSejJFbkv0FMO9SMiQbjI3n5NQuCrSIBqP66ggqyz2a6t2qEolKrMjhQ3+W/xXgUQ+Q==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -6803,7 +6837,7 @@
         "figures": "^3.0.0",
         "lodash": "^4.17.21",
         "mute-stream": "0.0.8",
-        "ora": "^5.3.0",
+        "ora": "^5.4.1",
         "run-async": "^2.4.0",
         "rxjs": "^7.2.0",
         "string-width": "^4.1.0",
@@ -6947,9 +6981,9 @@
       }
     },
     "node_modules/is-callable": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7086,12 +7120,12 @@
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "node_modules/is-regex": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.2"
+        "has-tostringtag": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7108,6 +7142,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -7118,9 +7160,12 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -7166,6 +7211,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isarray": {
@@ -7299,9 +7355,12 @@
       }
     },
     "node_modules/iterate-iterator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
-      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
+      "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/iterate-value": {
       "version": "1.0.2",
@@ -8447,11 +8506,12 @@
       }
     },
     "node_modules/jest-expect-har": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/jest-expect-har/-/jest-expect-har-2.0.3.tgz",
-      "integrity": "sha512-bYEw2CwtrBLDEG5x9tEOklcybBjRRm1U1NaTL2pI1RuLmZU67hoH/gYqRxbxHoVCqjy3JCvvsc4MpOZWZiaPVQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jest-expect-har/-/jest-expect-har-3.0.0.tgz",
+      "integrity": "sha512-+z+O5TE2uVoQJARRvaRvcquB23AfwDEXJ/jQA43irWeMWp/7l64NmljEx94+wiaKW6RR9I4WJ2MUlsbJ96NaIw==",
       "dev": true,
       "dependencies": {
+        "@types/har-format": "^1.2.8",
         "har-validator": "^5.1.5"
       },
       "engines": {
@@ -10627,9 +10687,9 @@
       ]
     },
     "node_modules/jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11367,9 +11427,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11476,9 +11536,9 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-16.0.4.tgz",
-      "integrity": "sha512-gYXdotuR33sCJ1QhO13eiIJ6uYes3TrSkRSmctHQxLrToTfcYXVDv9RN7IFaHJiepMJfi73HD96ru7NeYTYbPQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.0.tgz",
+      "integrity": "sha512-iaikb9s+xUi9AYqhak9nxX6H4lWUBEZ9FNQVzNb/N/lnD3Ue4dVYZ0ykMbdA+Rk0CK747RUJR4GH3j0HGJNIQQ==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -11487,7 +11547,7 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^5.0.1",
@@ -12500,9 +12560,9 @@
       "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
     },
     "node_modules/rxjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
-      "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
       "dependencies": {
         "tslib": "~2.1.0"
       }
@@ -12953,9 +13013,9 @@
       }
     },
     "node_modules/swagger-inline": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-4.2.0.tgz",
-      "integrity": "sha512-AzxINWpshpohcyekZTR+RB6sTFm4HakuSIJ1gp6+7nZgnJM84/q0cSMU8OjhgOaN4X/d/Jux0gFtOSdMwrzq8g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-4.2.2.tgz",
+      "integrity": "sha512-lu0PDx62Zp/rXQk7td0eAlincrpiVKfj/GPvel50+zVxfK1sI//kh/JSSm3EnVIibvjmFOojl+NTOcVOsrJPTA==",
       "dependencies": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",
@@ -13750,11 +13810,11 @@
       "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
     },
     "@babel/code-frame": {
-      "version": "7.15.8",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-      "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "requires": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.16.0"
       }
     },
     "@babel/compat-data": {
@@ -13994,11 +14054,11 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
@@ -14127,9 +14187,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
+      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -15622,15 +15682,15 @@
       }
     },
     "@readme/better-ajv-errors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.1.0.tgz",
-      "integrity": "sha512-z1kzTcXpfM3X3TJiRpPwUJjRxfHQz3GBgvIDK6+sUn6/6lv1hHMGljiwgL/ViCShp6PRNbgGPhRWJOiJDffwYw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.1.1.tgz",
+      "integrity": "sha512-3FmPBv2fYj2Qgvg8Qq3wEL7CxLPA6nwkVGafdEfS/85DIUx9z0iZcHu48no/l0HOk9PCKUDqpinN6bTtLxD0og==",
       "requires": {
-        "@babel/code-frame": "^7.15.8",
-        "@babel/runtime": "^7.15.4",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/runtime": "^7.16.0",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "leven": "^3.1.0"
       },
       "dependencies": {
@@ -15706,10 +15766,17 @@
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       }
     },
+    "@readme/oas-examples": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
+      "integrity": "sha512-zEK4w0BtSc5f4To7LyFOyGdv/El2oOy/xbU3KW3kzmbH3P4ZFYAHpMrXViZYsKjUZJ5w8VGNJeVfTXVs89eZkA==",
+      "dev": true
+    },
     "@readme/oas-extensions": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-13.7.0.tgz",
-      "integrity": "sha512-z+zSUfsz93puBOy4rITQSnwH3OBpv/6uJCntzAL1zY2hVKTSmN94Yj+wB3uqOez6YemLQTze0ujJbYpNPUnKcQ=="
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.0.0.tgz",
+      "integrity": "sha512-7CC5rcATBH0M2ZhHfX9RoHC8kSOcnKjvHXDb9gswUlLNQcLyRzg8ycQhSIJQna+6BSuHMZ79Den+Xw0z+P6Lpg==",
+      "requires": {}
     },
     "@readme/openapi-parser": {
       "version": "1.1.0",
@@ -15919,6 +15986,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/har-format": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.8.tgz",
+      "integrity": "sha512-OP6L9VuZNdskgNN3zFQQ54ceYD8OLq5IbqO4VK91ORLfOm7WdT/CiT/pHEBSQEqCInJ2y3O6iCm/zGtPElpgJQ==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -16356,15 +16429,15 @@
       }
     },
     "array.prototype.map": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.3.tgz",
-      "integrity": "sha512-nNcb30v0wfDyIe26Yif3PcV1JXQp4zEeEfupG7L4SRjnD6HLbO5b2a7eVSba53bOx4YCHYMBHt+Fp4vYstneRA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.4.tgz",
+      "integrity": "sha512-Qds9QnX7A0qISY7JT5WuJO0NJPE9CMlC6JzHQfhpqAAQQzufVRoeH7EzUY5GcPTx72voG8LV/5eo+b8Qi8hmhA==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
+        "es-abstract": "^1.19.0",
         "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.5"
+        "is-string": "^1.0.7"
       }
     },
     "arrify": {
@@ -16757,9 +16830,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
-      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
     },
     "cli-width": {
       "version": "3.0.0",
@@ -17231,21 +17304,24 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.4.tgz",
-      "integrity": "sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-symbols": "^1.0.2",
         "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.3",
+        "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.3",
-        "is-string": "^1.0.6",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
         "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
@@ -17255,16 +17331,16 @@
       }
     },
     "es-aggregate-error": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.5.tgz",
-      "integrity": "sha512-lCJhahEBlzD0WnPEpFCWqjxm4DI4fzuq1PVxLfsGdHImCWSUhASlv+lrBX4Wc47g62SAO4+axBUfUMgJYIhilg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.7.tgz",
+      "integrity": "sha512-Zob/KUAOQUTvCzqgL2FEgtqNLPX5rYW3VhlldZ6La4W2mJUv3J8DmD0/sPxuD+kSAKF6nuceJ3uOSvCaaTLUyQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
+        "es-abstract": "^1.19.0",
         "function-bind": "^1.1.1",
-        "functions-have-names": "^1.2.1",
-        "get-intrinsic": "^1.0.1",
-        "globalthis": "^1.0.1"
+        "functions-have-names": "^1.2.2",
+        "get-intrinsic": "^1.1.1",
+        "globalthis": "^1.0.2"
       }
     },
     "es-array-method-boxes-properly": {
@@ -18250,11 +18326,11 @@
       }
     },
     "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
       "requires": {
-        "type": "^2.0.0"
+        "type": "^2.5.0"
       },
       "dependencies": {
         "type": {
@@ -18463,6 +18539,15 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "git-raw-commits": {
       "version": "2.0.10",
@@ -18839,9 +18924,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
-      "integrity": "sha512-DHLKJwLPNgkfwNmsuEUKSejJFbkv0FMO9SMiQbjI3n5NQuCrSIBqP66ggqyz2a6t2qEolKrMjhQ3+W/xXgUQ+Q==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -18851,7 +18936,7 @@
         "figures": "^3.0.0",
         "lodash": "^4.17.21",
         "mute-stream": "0.0.8",
-        "ora": "^5.3.0",
+        "ora": "^5.4.1",
         "run-async": "^2.4.0",
         "rxjs": "^7.2.0",
         "string-width": "^4.1.0",
@@ -18952,9 +19037,9 @@
       }
     },
     "is-callable": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
     },
     "is-core-module": {
       "version": "2.7.0",
@@ -19043,18 +19128,23 @@
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-regex": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "requires": {
         "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.2"
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-set": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
       "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
     },
     "is-stream": {
       "version": "2.0.0",
@@ -19063,9 +19153,12 @@
       "dev": true
     },
     "is-string": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -19094,6 +19187,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+    },
+    "is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -19200,9 +19301,9 @@
       }
     },
     "iterate-iterator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
-      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
+      "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw=="
     },
     "iterate-value": {
       "version": "1.0.2",
@@ -20078,11 +20179,12 @@
       }
     },
     "jest-expect-har": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/jest-expect-har/-/jest-expect-har-2.0.3.tgz",
-      "integrity": "sha512-bYEw2CwtrBLDEG5x9tEOklcybBjRRm1U1NaTL2pI1RuLmZU67hoH/gYqRxbxHoVCqjy3JCvvsc4MpOZWZiaPVQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jest-expect-har/-/jest-expect-har-3.0.0.tgz",
+      "integrity": "sha512-+z+O5TE2uVoQJARRvaRvcquB23AfwDEXJ/jQA43irWeMWp/7l64NmljEx94+wiaKW6RR9I4WJ2MUlsbJ96NaIw==",
       "dev": true,
       "requires": {
+        "@types/har-format": "^1.2.8",
         "har-validator": "^5.1.5"
       }
     },
@@ -21763,9 +21865,9 @@
       "dev": true
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg=="
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -22333,9 +22435,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -22429,9 +22531,9 @@
       "dev": true
     },
     "oas": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-16.0.4.tgz",
-      "integrity": "sha512-gYXdotuR33sCJ1QhO13eiIJ6uYes3TrSkRSmctHQxLrToTfcYXVDv9RN7IFaHJiepMJfi73HD96ru7NeYTYbPQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.0.tgz",
+      "integrity": "sha512-iaikb9s+xUi9AYqhak9nxX6H4lWUBEZ9FNQVzNb/N/lnD3Ue4dVYZ0ykMbdA+Rk0CK747RUJR4GH3j0HGJNIQQ==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "cardinal": "^2.1.1",
@@ -22440,7 +22542,7 @@
         "inquirer": "^8.1.2",
         "json-schema-merge-allof": "^0.8.1",
         "json2yaml": "^1.1.0",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
         "oas-normalize": "^5.0.1",
@@ -23200,9 +23302,9 @@
       "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
     },
     "rxjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
-      "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
       "requires": {
         "tslib": "~2.1.0"
       },
@@ -23586,9 +23688,9 @@
       }
     },
     "swagger-inline": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-4.2.0.tgz",
-      "integrity": "sha512-AzxINWpshpohcyekZTR+RB6sTFm4HakuSIJ1gp6+7nZgnJM84/q0cSMU8OjhgOaN4X/d/Jux0gFtOSdMwrzq8g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-4.2.2.tgz",
+      "integrity": "sha512-lu0PDx62Zp/rXQk7td0eAlincrpiVKfj/GPvel50+zVxfK1sI//kh/JSSm3EnVIibvjmFOojl+NTOcVOsrJPTA==",
       "requires": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -22,27 +22,23 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@readme/oas-extensions": "^13.7.0",
-    "oas": "^16.0.3",
+    "@readme/oas-extensions": "^14.0.0",
+    "oas": "^17.1.0",
     "parse-data-url": "^4.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^14.1.0",
     "@commitlint/config-conventional": "^14.1.0",
     "@readme/eslint-config": "^7.2.2",
+    "@readme/oas-examples": "^4.3.2",
     "datauri": "^4.1.0",
     "eslint": "^7.32.0",
     "husky": "^7.0.4",
     "jest": "^27.3.1",
-    "jest-expect-har": "^2.0.2",
+    "jest-expect-har": "^3.0.0",
     "prettier": "^2.4.1"
   },
   "prettier": "@readme/eslint-config/prettier",
-  "jest": {
-    "setupFilesAfterEnv": [
-      "jest-expect-har"
-    ]
-  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"

--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,8 @@ module.exports = (
     operation = new Operation(oas, operationSchema.path, operationSchema.method, operationSchema);
   }
 
+  const apiDefinition = oas.getDefinition();
+
   const formData = {
     ...defaultFormDataTypes,
     server: {
@@ -140,7 +142,7 @@ module.exports = (
   const parameters = [];
   function addParameter(param) {
     if (param.$ref) {
-      parameters.push(findSchemaDefinition(param.$ref, oas));
+      parameters.push(findSchemaDefinition(param.$ref, apiDefinition));
     } else {
       parameters.push(param);
     }
@@ -149,8 +151,8 @@ module.exports = (
   operation.getParameters().forEach(addParameter);
 
   // Does this operation have any common parameters?
-  if (oas.paths && oas.paths[operation.path] && oas.paths[operation.path].parameters) {
-    oas.paths[operation.path].parameters.forEach(addParameter);
+  if (apiDefinition.paths && apiDefinition.paths[operation.path] && apiDefinition.paths[operation.path].parameters) {
+    apiDefinition.paths[operation.path].parameters.forEach(addParameter);
   }
 
   har.url = har.url.replace(/{([-_a-zA-Z0-9[\]]+)}/g, (full, key) => {
@@ -242,7 +244,7 @@ module.exports = (
     });
   }
 
-  let requestBody = getSchema(operation.schema, oas);
+  let requestBody = getSchema(operation.schema, apiDefinition);
   if (requestBody) {
     requestBody = requestBody.schema;
   } else {
@@ -396,7 +398,7 @@ module.exports = (
     // TODO pass these values through the formatter?
     securityRequirements.forEach(schemes => {
       Object.keys(schemes).forEach(security => {
-        const securityValue = configureSecurity(oas, auth, security);
+        const securityValue = configureSecurity(apiDefinition, auth, security);
         if (!securityValue) {
           return;
         }

--- a/src/lib/configure-security.js
+++ b/src/lib/configure-security.js
@@ -3,13 +3,13 @@ function harValue(type, value) {
   return { type, value };
 }
 
-module.exports = function configureSecurity(oas, values, scheme) {
+module.exports = function configureSecurity(apiDefinition, values, scheme) {
   if (!scheme) return {};
 
   if (Object.keys(values || {}).length === 0) return undefined;
 
-  if (!oas.components.securitySchemes[scheme]) return undefined;
-  const security = oas.components.securitySchemes[scheme];
+  if (!apiDefinition.components.securitySchemes[scheme]) return undefined;
+  const security = apiDefinition.components.securitySchemes[scheme];
 
   if (security.type === 'http') {
     if (security.scheme === 'basic') {


### PR DESCRIPTION
## 🧰 What's being changed?

Lots of major dependency upgrades here for our ongoing OpenAPI 3.1 support project.

* [x] `oas` → v17
  * ~95% rewrite in Typescript
  * A change in how core API definitions are stored on the main `Oas` class instance
  * Heaps of new helpers methods and accessors
* [x] `@readme/oas-extensions` → v14
  * Full rewrite in Typescript
  * Compatibility fixes for `oas@17`
* [x] `jest-expect-har` → v3
  * Full rewrite in Typescript
  * Matcher must now be manually configured into `expect.extend()`
  * https://github.com/readmeio/jest-expect-har/releases/tag/3.0.0

This library is a prime candidate for a transition to TS but not now. 😰 