### PR TITLE
fix: bug where nested object formData would be improperly converted as a string

### DIFF
--- a/__tests__/__fixtures__/formData-nested-object.json
+++ b/__tests__/__fixtures__/formData-nested-object.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "formData with a nested object payload",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/anything": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "Request": {
+                        "type": "object",
+                        "properties": {
+                          "MerchantId": {
+                            "type": "string",
+                            "format": "uuid"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1571,6 +1571,24 @@ describe('requestBody', () => {
         { name: 'b', value: '1,2,3' },
       ]);
     });
+
+    it('should support nested objects', () => {
+      // eslint-disable-next-line global-require
+      const spec = new Oas(require('./__fixtures__/formData-nested-object.json'));
+      const operation = spec.operation('/anything', 'post');
+      const formData = {
+        id: 12345,
+        Request: {
+          MerchantId: 'buster',
+        },
+      };
+
+      const har = oasToHar(spec, operation, { formData });
+      expect(har.log.entries[0].request.postData.params).toStrictEqual([
+        { name: 'id', value: 12345 },
+        { name: 'Request', value: '{"MerchantId":"buster"}' },
+      ]);
+    });
   });
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,16 @@ function stringify(json) {
   return JSON.stringify(removeUndefinedObjects(typeof json.RAW_BODY !== 'undefined' ? json.RAW_BODY : json));
 }
 
+function stringifyParameter(param) {
+  if (param === null || isPrimitive(param)) {
+    return param;
+  } else if (Array.isArray(param) && param.every(isPrimitive)) {
+    return String(param);
+  }
+
+  return JSON.stringify(param);
+}
+
 function appendHarValue(harParam, name, value) {
   if (typeof value === 'undefined') return;
 
@@ -262,7 +272,7 @@ module.exports = (
           Object.keys(cleanFormData).forEach(name => {
             har.postData.params.push({
               name,
-              value: String(cleanFormData[name]),
+              value: stringifyParameter(cleanFormData[name]),
             });
           });
         }


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a bug in our `formData` value handling where if one of those values was a nested object, or was an array of objects, we'd improperly convert it to `[object Object]`. With this work we'll now intelligently handle this data.

Fix in support of RM-2902.

## 🧬 Testing

See tests