### PR TITLE
test: overhauling the test suite to make it easier to maintain

### DIFF
--- a/__tests__/__fixtures__/requestBody-raw_body.json
+++ b/__tests__/__fixtures__/requestBody-raw_body.json
@@ -1,0 +1,78 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "`RAW_BODY` handling",
+    "description": "`RAW_BODY` is a ReadMe-specific thing where we'll interpret any of the properties contents as raw JSON.\n\nhttps://docs.readme.com/docs/raw-body-content",
+    "version": "1.0.0"
+  },
+  "server": [
+    {
+      "url": "https://httpbin.org/anything"
+    }
+  ],
+  "paths": {
+    "/primitive": {
+      "post": {
+        "summary": "`RAW_BODY` handling of primitive content.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "RAW_BODY": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/json": {
+      "post": {
+        "summary": "`RAW_BODY` handling of string content with `format: json`.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "RAW_BODY": {
+                    "type": "string",
+                    "format": "json"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/objects": {
+      "post": {
+        "summary": "`RAW_BODY` handling of shaped objects.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "RAW_BODY": {
+                    "type": "object",
+                    "properties": {
+                      "a": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/__tests__/__fixtures__/security.json
+++ b/__tests__/__fixtures__/security.json
@@ -1,0 +1,75 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Support for different security types"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org/anything"
+    }
+  ],
+  "paths": {
+    "/header": {
+      "post": {
+        "security": [
+          {
+            "auth_header": []
+          }
+        ]
+      }
+    },
+    "/query": {
+      "post": {
+        "security": [
+          {
+            "auth_query": []
+          }
+        ]
+      }
+    },
+    "/cookie": {
+      "post": {
+        "security": [
+          {
+            "auth_cookie": []
+          }
+        ]
+      }
+    },
+    "/multiple-auth-or": {
+      "post": {
+        "security": [{ "auth_header": [] }, { "auth_headerAlt": [] }]
+      }
+    },
+    "/multiple-auth-and": {
+      "post": {
+        "security": [{ "auth_header": [], "auth_headerAlt": [] }]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "auth_header": {
+        "type": "apiKey",
+        "name": "x-auth-header",
+        "in": "header"
+      },
+      "auth_headerAlt": {
+        "type": "apiKey",
+        "name": "x-auth-header-alt",
+        "in": "header"
+      },
+      "auth_query": {
+        "type": "apiKey",
+        "name": "authQuery",
+        "in": "query"
+      },
+      "auth_cookie": {
+        "type": "apiKey",
+        "name": "authCookie",
+        "in": "cookie"
+      }
+    }
+  }
+}

--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -1,0 +1,107 @@
+const Oas = require('oas').default;
+const oasToHar = require('../src');
+const toBeAValidHAR = require('jest-expect-har').default;
+
+const security = require('./__fixtures__/security.json');
+
+expect.extend({ toBeAValidHAR });
+
+const spec = new Oas(security);
+
+test('should work for header auth', () => {
+  expect(
+    oasToHar(spec, spec.operation('/header', 'post'), {}, { auth_header: 'value' }).log.entries[0].request.headers
+  ).toStrictEqual([
+    {
+      name: 'x-auth-header',
+      value: 'value',
+    },
+  ]);
+});
+
+test('should work for query auth', () => {
+  expect(
+    oasToHar(
+      spec,
+      spec.operation('/query', 'post'),
+      {},
+      {
+        auth_query: 'value',
+      }
+    ).log.entries[0].request.queryString
+  ).toStrictEqual([
+    {
+      name: 'authQuery',
+      value: 'value',
+    },
+  ]);
+});
+
+test('should work for cookie auth', () => {
+  expect(
+    oasToHar(
+      spec,
+      spec.operation('/cookie', 'post'),
+      {},
+      {
+        auth_cookie: 'value',
+      }
+    ).log.entries[0].request.cookies
+  ).toStrictEqual([
+    {
+      name: 'authCookie',
+      value: 'value',
+    },
+  ]);
+});
+
+test('should work for multiple (||)', () => {
+  expect(
+    oasToHar(
+      spec,
+      spec.operation('/multiple-auth-or', 'post'),
+      {},
+      {
+        auth_header: 'value',
+        auth_headerAlt: 'value',
+      }
+    ).log.entries[0].request.headers
+  ).toStrictEqual([
+    {
+      name: 'x-auth-header',
+      value: 'value',
+    },
+    {
+      name: 'x-auth-header-alt',
+      value: 'value',
+    },
+  ]);
+});
+
+test('should work for multiple (&&)', () => {
+  expect(
+    oasToHar(
+      spec,
+      spec.operation('/multiple-auth-and', 'post'),
+      {},
+      {
+        auth_header: 'value',
+        auth_headerAlt: 'value',
+      }
+    ).log.entries[0].request.headers
+  ).toStrictEqual([
+    {
+      name: 'x-auth-header',
+      value: 'value',
+    },
+    {
+      name: 'x-auth-header-alt',
+      value: 'value',
+    },
+  ]);
+});
+
+test('should not set non-existent values', () => {
+  const har = oasToHar(spec, spec.operation('/header', 'post'), {}, {});
+  expect(har.log.entries[0].request.headers).toStrictEqual([]);
+});

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,22 +1,15 @@
 const extensions = require('@readme/oas-extensions');
 const Oas = require('oas').default;
-const path = require('path');
-const datauri = require('datauri');
 const oasToHar = require('../src');
 const toBeAValidHAR = require('jest-expect-har').default;
 
 const petstore = require('@readme/oas-examples/3.0/json/petstore.json');
-const commonParameters = require('./__fixtures__/common-parameters.json');
-const multipartFormData = require('./__fixtures__/multipart-form-data.json');
-const multipartFormDataArrayOfFiles = require('./__fixtures__/multipart-form-data/array-of-files.json');
 const serverVariables = require('./__fixtures__/server-variables.json');
 
 expect.extend({ toBeAValidHAR });
 
-const oas = new Oas({});
-
-test('should output a har object', async () => {
-  const har = oasToHar(oas);
+test('should output a HAR object if no operation information is supplied', async () => {
+  const har = oasToHar(new Oas({}));
 
   await expect(har).toBeAValidHAR();
   expect(har).toStrictEqual({
@@ -65,21 +58,25 @@ test('should accept an Operation instance as the operation schema', async () => 
   });
 });
 
-test('should uppercase the method', async () => {
-  const har = oasToHar(oas, { path: '/', method: 'get' });
-
-  expect(har.log.entries[0].request.method).toBe('GET');
-  await expect(har).toBeAValidHAR();
-});
-
 describe('url', () => {
   it('should be constructed from oas.url()', () => {
-    expect(oasToHar(oas, { path: '', method: 'get' }).log.entries[0].request.url).toBe(oas.url());
+    const spec = new Oas(petstore);
+    const operation = spec.operation('/pet', 'post');
+    const har = oasToHar(spec, operation);
+
+    expect(har.log.entries[0].request.url).toBe(`${spec.url()}/pet`);
   });
 
-  // TODO this should probably happen within the Operation class
   it('should replace whitespace with %20', () => {
-    expect(oasToHar(oas, { path: '/path with spaces', method: '' }).log.entries[0].request.url).toBe(
+    const spec = new Oas({
+      paths: {
+        '/path with spaces': {
+          get: {},
+        },
+      },
+    });
+
+    expect(oasToHar(spec, spec.operation('/path with spaces', 'get')).log.entries[0].request.url).toBe(
       'https://example.com/path%20with%20spaces'
     );
   });
@@ -143,1522 +140,49 @@ describe('url', () => {
 
   describe('proxy url', () => {
     const proxyOas = new Oas({
+      paths: {
+        '/path': {
+          get: {},
+        },
+      },
       [extensions.PROXY_ENABLED]: true,
     });
 
     it('should not be prefixed with without option', () => {
-      expect(oasToHar(proxyOas, { path: '/path', method: 'get' }).log.entries[0].request.url).toBe(
-        'https://example.com/path'
-      );
+      const har = oasToHar(proxyOas, proxyOas.operation('/path', 'get'));
+      expect(har.log.entries[0].request.url).toBe('https://example.com/path');
     });
 
     it('should be prefixed with try.readme.io with option', () => {
-      expect(
-        oasToHar(proxyOas, { path: '/path', method: 'get' }, {}, {}, { proxyUrl: true }).log.entries[0].request.url
-      ).toBe('https://try.readme.io/https://example.com/path');
+      const har = oasToHar(proxyOas, proxyOas.operation('/path', 'get'), {}, {}, { proxyUrl: true });
+      expect(har.log.entries[0].request.url).toBe('https://try.readme.io/https://example.com/path');
     });
-  });
-});
-
-describe('parameters', () => {
-  describe('path', () => {
-    it('should pass through unknown path params', () => {
-      expect(oasToHar(oas, { path: '/param-path/{id}', method: '' }).log.entries[0].request.url).toBe(
-        'https://example.com/param-path/id'
-      );
-
-      expect(
-        oasToHar(oas, {
-          path: '/param-path/{id}',
-          method: 'get',
-          parameters: [
-            {
-              name: 'something-else',
-              in: 'path',
-              required: true,
-            },
-          ],
-        }).log.entries[0].request.url
-      ).toBe('https://example.com/param-path/id');
-    });
-
-    it.each([
-      [
-        'should not error if empty object passed in for values',
-        {
-          parameters: [{ name: 'id', in: 'path', required: true }],
-        },
-        {},
-        'https://example.com/param-path/id',
-      ],
-      [
-        'should use default if no value',
-        {
-          parameters: [{ name: 'id', in: 'path', required: true, schema: { default: '123' } }],
-        },
-        {},
-        'https://example.com/param-path/123',
-      ],
-      [
-        'should add path values to the url',
-        {
-          parameters: [{ name: 'id', in: 'path', required: true }],
-        },
-        { path: { id: '456' } },
-        'https://example.com/param-path/456',
-      ],
-      [
-        'should add falsy values to the url',
-        {
-          parameters: [{ name: 'id', in: 'path', required: true }],
-        },
-        { path: { id: 0 } },
-        'https://example.com/param-path/0',
-      ],
-    ])('%s', async (_, operation, formData, expectedUrl) => {
-      const har = oasToHar(
-        oas,
-        {
-          path: '/param-path/{id}',
-          method: 'get',
-          ...operation,
-        },
-        formData
-      );
-
-      await expect(har).toBeAValidHAR();
-
-      expect(har.log.entries[0].request.url).toStrictEqual(expectedUrl);
-    });
-  });
-
-  describe('query', () => {
-    it.each([
-      [
-        'should not add on empty unrequired values',
-        {
-          parameters: [{ name: 'a', in: 'query' }],
-        },
-      ],
-      [
-        'should not add the parameter name as a value if required but missing',
-        {
-          parameters: [{ name: 'a', in: 'query', required: true }],
-        },
-      ],
-      [
-        'should set defaults if no value provided but is required',
-        {
-          parameters: [{ name: 'a', in: 'query', required: true, schema: { default: 'value' } }],
-        },
-        {},
-        [{ name: 'a', value: 'value' }],
-      ],
-      [
-        'should pass in value if one is set and prioritise provided values',
-        {
-          parameters: [{ name: 'a', in: 'query', required: true, schema: { default: 'value' } }],
-        },
-        { query: { a: 'test' } },
-        [{ name: 'a', value: 'test' }],
-      ],
-      [
-        'should add falsy values to the querystring',
-        {
-          parameters: [{ name: 'id', in: 'query' }],
-        },
-        { query: { id: 0 } },
-        [{ name: 'id', value: '0' }],
-      ],
-      [
-        'should handle null array values',
-        {
-          parameters: [{ name: 'id', in: 'query' }],
-        },
-        { query: { id: [null, null] } },
-        [{ name: 'id', value: '&id=' }],
-      ],
-      [
-        'should handle null values',
-        {
-          parameters: [{ name: 'id', in: 'query' }],
-        },
-        { query: { id: null } },
-        [{ name: 'id', value: 'null' }],
-      ],
-      [
-        'should handle null default values',
-        {
-          parameters: [
-            {
-              name: 'id',
-              in: 'query',
-              required: true,
-              schema: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-                default: [null, null],
-              },
-            },
-          ],
-        },
-        { query: {} },
-        [{ name: 'id', value: '&id=' }],
-      ],
-    ])('%s', async (_, operation = {}, formData = {}, expectedQueryString = []) => {
-      const har = oasToHar(
-        oas,
-        {
-          path: '/query',
-          method: 'get',
-          ...operation,
-        },
-        formData
-      );
-
-      await expect(har).toBeAValidHAR();
-      expect(har.log.entries[0].request.queryString).toStrictEqual(expectedQueryString);
-    });
-
-    describe('URI encoding', () => {
-      const spec = new Oas({
-        servers: [{ url: 'https://httpbin.org/' }],
-        paths: {
-          '/anything': {
-            get: {
-              parameters: [
-                { name: 'stringPound', in: 'query', schema: { type: 'string' } },
-                { name: 'stringPound2', in: 'query', schema: { type: 'string' } },
-                { name: 'stringHash', in: 'query', schema: { type: 'string' } },
-                { name: 'stringArray', in: 'query', schema: { type: 'string' } },
-                { name: 'stringWeird', in: 'query', schema: { type: 'string' } },
-                { name: 'array', in: 'query', schema: { type: 'array', items: { type: 'string' } } },
-              ],
-            },
-          },
-        },
-      });
-
-      it('should encode query parameters', async () => {
-        const formData = {
-          query: {
-            stringPound: 'something&nothing=true',
-            stringHash: 'hash#data',
-            stringArray: 'where[4]=10',
-            stringWeird: 'properties["$email"] == "testing"',
-            array: [
-              encodeURIComponent('something&nothing=true'), // This is already encoded so it shouldn't be double encoded.
-              'nothing&something=false',
-              'another item',
-            ],
-          },
-        };
-
-        const operation = spec.operation('/anything', 'get');
-
-        const har = oasToHar(spec, operation, formData);
-        await expect(har).toBeAValidHAR();
-
-        expect(har.log.entries[0].request.queryString).toStrictEqual([
-          { name: 'stringPound', value: 'something%26nothing%3Dtrue' },
-          { name: 'stringHash', value: 'hash%23data' },
-          { name: 'stringArray', value: 'where%5B4%5D%3D10' },
-          {
-            name: 'stringWeird',
-            value: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
-          },
-          { name: 'array', value: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item' },
-        ]);
-      });
-
-      it('should not double encode query parameters that are already encoded', async () => {
-        const formData = {
-          query: {
-            stringPound: encodeURIComponent('something&nothing=true'),
-            stringHash: encodeURIComponent('hash#data'),
-            stringArray: encodeURIComponent('where[4]=10'),
-            stringWeird: encodeURIComponent('properties["$email"] == "testing"'),
-            array: [
-              'something&nothing=true', // Should still encode this one eventhrough the others are already encoded.
-              encodeURIComponent('nothing&something=false'),
-              encodeURIComponent('another item'),
-            ],
-          },
-        };
-
-        const operation = spec.operation('/anything', 'get');
-
-        const har = oasToHar(spec, operation, formData);
-        await expect(har).toBeAValidHAR();
-
-        expect(har.log.entries[0].request.queryString).toStrictEqual([
-          { name: 'stringPound', value: 'something%26nothing%3Dtrue' },
-          { name: 'stringHash', value: 'hash%23data' },
-          { name: 'stringArray', value: 'where%5B4%5D%3D10' },
-          {
-            name: 'stringWeird',
-            value: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
-          },
-          { name: 'array', value: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item' },
-        ]);
-      });
-    });
-  });
-
-  describe('cookie', () => {
-    it.each([
-      [
-        'should not add on empty unrequired values',
-        {
-          parameters: [{ name: 'a', in: 'cookie' }],
-        },
-      ],
-      [
-        'should not add the parameter name as a value if required but missing',
-        {
-          parameters: [{ name: 'a', in: 'cookie', required: true }],
-        },
-      ],
-      [
-        'should set defaults if no value provided but is required',
-        {
-          parameters: [{ name: 'a', in: 'cookie', required: true, schema: { default: 'value' } }],
-        },
-        {},
-        [{ name: 'a', value: 'value' }],
-      ],
-      [
-        'should pass in value if one is set and prioritize provided values',
-        {
-          parameters: [{ name: 'a', in: 'cookie', required: true, schema: { default: 'value' } }],
-        },
-        { cookie: { a: 'test' } },
-        [{ name: 'a', value: 'test' }],
-      ],
-      [
-        'should add falsy values to the cookies',
-        {
-          parameters: [{ name: 'id', in: 'cookie' }],
-        },
-        { cookie: { id: 0 } },
-        [{ name: 'id', value: '0' }],
-      ],
-    ])('%s', async (_, operation = {}, formData = {}, expectedCookies = []) => {
-      const har = oasToHar(
-        oas,
-        {
-          path: '/',
-          method: 'get',
-          ...operation,
-        },
-        formData
-      );
-
-      await expect(har).toBeAValidHAR();
-
-      expect(har.log.entries[0].request.cookies).toStrictEqual(expectedCookies);
-    });
-  });
-
-  describe('header', () => {
-    it.each([
-      [
-        'should not add on empty unrequired values',
-        {
-          parameters: [{ name: 'a', in: 'header' }],
-        },
-      ],
-      [
-        'should not add the parameter name as a value if required but missing',
-        {
-          parameters: [{ name: 'a', in: 'header', required: true }],
-        },
-      ],
-      [
-        'should set defaults if no value provided but is required',
-        {
-          parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
-        },
-        {},
-        [{ name: 'a', value: 'value' }],
-      ],
-      [
-        'should pass in value if one is set and prioritise provided values',
-        {
-          parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
-        },
-        { header: { a: 'test' } },
-        [{ name: 'a', value: 'test' }],
-      ],
-      [
-        'should pass accept header if endpoint expects a content back from response',
-        {
-          parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
-          responses: {
-            200: {
-              content: {
-                'application/xml': { type: 'array' },
-                'application/json': { type: 'array' },
-              },
-            },
-          },
-        },
-        {},
-        [
-          { name: 'Accept', value: 'application/xml' },
-          { name: 'a', value: 'value' },
-        ],
-      ],
-      [
-        'should only add one accept header',
-        {
-          responses: {
-            200: {
-              content: {
-                'application/xml': {},
-              },
-            },
-            400: {
-              content: {
-                'application/json': {},
-              },
-            },
-          },
-        },
-        {},
-        [{ name: 'Accept', value: 'application/xml' }],
-      ],
-      [
-        'should only receive one accept header if specified in values',
-        {
-          parameters: [{ name: 'Accept', in: 'header' }],
-          responses: {
-            200: {
-              content: {
-                'application/json': {},
-                'application/xml': {},
-              },
-            },
-          },
-        },
-        { header: { Accept: 'application/xml' } },
-        [{ name: 'Accept', value: 'application/xml' }],
-      ],
-      [
-        'should add accept header if specified in formdata',
-        {
-          responses: {
-            200: {
-              content: {
-                'application/json': {},
-                'application/xml': {},
-              },
-            },
-          },
-        },
-        { header: { Accept: 'application/xml' } },
-        [{ name: 'Accept', value: 'application/xml' }],
-      ],
-      [
-        'should add falsy values to the headers',
-        {
-          parameters: [{ name: 'id', in: 'header' }],
-        },
-        { header: { id: 0 } },
-        [{ name: 'id', value: '0' }],
-      ],
-    ])('%s', async (_, operation = {}, formData = {}, expectedHeaders = []) => {
-      const har = oasToHar(
-        oas,
-        {
-          path: '/header',
-          method: 'get',
-          ...operation,
-        },
-        formData
-      );
-
-      await expect(har).toBeAValidHAR();
-
-      expect(har.log.entries[0].request.headers).toStrictEqual(expectedHeaders);
-    });
-  });
-});
-
-describe('requestBody', () => {
-  describe('body values', () => {
-    it('should not add on empty unrequired values', () => {
-      const pathOperation = {
-        path: '/body',
-        method: 'get',
-        requestBody: {
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  a: {
-                    type: 'string',
-                  },
-                },
-              },
-            },
-          },
-        },
-      };
-
-      expect(oasToHar(oas, pathOperation).log.entries[0].request.postData).toBeUndefined();
-    });
-
-    // TODO extensions[SEND_DEFAULTS]
-    it.skip('should set defaults if no value provided but is required', () => {
-      expect(
-        oasToHar(oas, {
-          path: '/body',
-          method: 'get',
-          requestBody: {
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  required: ['a'],
-                  properties: {
-                    a: {
-                      type: 'string',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        }).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify({ a: 'value' }));
-    });
-
-    it('should pass in value if one is set and prioritise provided values', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    required: ['a'],
-                    properties: {
-                      a: {
-                        type: 'string',
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { body: { a: 'test' } }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify({ a: 'test' }));
-    });
-
-    it('should work for RAW_BODY primitives', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      RAW_BODY: {
-                        type: 'string',
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { body: { RAW_BODY: 'test' } }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify('test'));
-    });
-
-    it('should work for RAW_BODY json', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      RAW_BODY: {
-                        type: 'string',
-                        format: 'json',
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { body: { RAW_BODY: '{ "a": 1 }' } }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify({ a: 1 }));
-    });
-
-    it('should return empty for falsy RAW_BODY primitives', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      RAW_BODY: {
-                        type: 'string',
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { body: { RAW_BODY: '' } }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify(''));
-    });
-
-    it('should work for RAW_BODY objects', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      RAW_BODY: {
-                        type: 'object',
-                        properties: {
-                          a: {
-                            type: 'string',
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { body: { RAW_BODY: { a: 'test' } } }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify({ a: 'test' }));
-    });
-
-    it('should return empty for RAW_BODY objects', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      RAW_BODY: {
-                        type: 'object',
-                        properties: {
-                          a: {
-                            type: 'string',
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { body: { RAW_BODY: {} } }
-        ).log.entries[0].request.postData.text
-      ).toBeUndefined();
-    });
-
-    it('should return nothing for undefined body property', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      a: {
-                        type: 'string',
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { body: { a: undefined } }
-        ).log.entries[0].request.postData.text
-      ).toBeUndefined();
-    });
-
-    it('should work for schemas that require a lookup', () => {
-      expect(
-        oasToHar(
-          new Oas({
-            components: {
-              requestBodies: {
-                schema: {
-                  content: {
-                    'application/json': {
-                      schema: { type: 'object', properties: { a: { type: 'integer' } } },
-                    },
-                  },
-                },
-              },
-            },
-          }),
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              $ref: '#/components/requestBodies/schema',
-            },
-          },
-          { body: { a: 123 } }
-        ).log.entries[0].request.postData.text
-      ).toStrictEqual(JSON.stringify({ a: 123 }));
-    });
-
-    it('should work for schemas that require a parameters lookup', () => {
-      expect(
-        oasToHar(
-          new Oas({
-            components: {
-              parameters: {
-                authorization: {
-                  name: 'Authorization',
-                  in: 'header',
-                },
-              },
-            },
-          }),
-          {
-            method: 'get',
-            parameters: [
-              {
-                $ref: '#/components/parameters/authorization',
-              },
-            ],
-          },
-          { header: { Authorization: 'test' } }
-        ).log.entries[0].request.headers[0].value
-      ).toBe('test');
-    });
-
-    it('should work for top level primitives', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'post',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'string',
-                  },
-                },
-              },
-            },
-          },
-          { body: 'string' }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify('string'));
-
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'post',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'integer',
-                    format: 'int64',
-                  },
-                },
-              },
-            },
-          },
-          { body: 123 }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify(123));
-
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'post',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'boolean',
-                  },
-                },
-              },
-            },
-          },
-          { body: true }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify(true));
-    });
-
-    it('should work for top level falsy primitives', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'post',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'string',
-                  },
-                },
-              },
-            },
-          },
-          { body: '' }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify(''));
-
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'post',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'integer',
-                    format: 'int64',
-                  },
-                },
-              },
-            },
-          },
-          { body: 0 }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify(0));
-
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'post',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'boolean',
-                  },
-                },
-              },
-            },
-          },
-          { body: false }
-        ).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify(false));
-    });
-
-    it('should not include objects with undefined sub properties', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      a: {
-                        type: 'object',
-                        properties: {
-                          b: {
-                            type: 'string',
-                          },
-                          c: {
-                            type: 'object',
-                            properties: {
-                              d: {
-                                type: 'string',
-                              },
-                            },
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { body: { a: { b: undefined, c: { d: undefined } } } }
-        ).log.entries[0].request.postData.text
-      ).toBeUndefined();
-    });
-
-    // When we first render the form, formData.body is undefined
-    // until something is typed into the form. When using anyOf/oneOf
-    // if we change the schema before typing anything into the form,
-    // then onChange is fired with `undefined` which causes
-    // this to error
-    it('should not error if `formData.body` is undefined', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      a: {
-                        type: 'string',
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { body: undefined }
-        ).log.entries[0].request.postData
-      ).toBeUndefined();
-    });
-
-    describe('content types', () => {
-      describe('multipart/form-data', () => {
-        let owlbert;
-
-        beforeAll(async () => {
-          owlbert = await datauri(path.join(__dirname, '__fixtures__', 'owlbert.png'));
-
-          // Doing this manually for now until when/if https://github.com/data-uri/datauri/pull/29 is accepted.
-          owlbert = owlbert.replace(';base64', `;name=${encodeURIComponent('owlbert.png')};base64`);
-        });
-
-        it('should handle multipart/form-data request bodies', () => {
-          const fixture = new Oas(multipartFormData);
-          const har = oasToHar(fixture, fixture.operation('/anything', 'post'), {
-            body: { orderId: 12345, userId: 67890, documentFile: owlbert },
-          });
-
-          expect(har.log.entries[0].request.headers).toStrictEqual([
-            { name: 'Content-Type', value: 'multipart/form-data' },
-          ]);
-
-          expect(har.log.entries[0].request.postData).toStrictEqual({
-            mimeType: 'multipart/form-data',
-            params: [
-              { name: 'orderId', value: '12345' },
-              { name: 'userId', value: '67890' },
-              {
-                contentType: 'image/png',
-                fileName: 'owlbert.png',
-                name: 'documentFile',
-                value: owlbert,
-              },
-            ],
-          });
-        });
-
-        it('should handle multipart/form-data request bodies where the filename contains parentheses', () => {
-          // Doing this manually for now until when/if https://github.com/data-uri/datauri/pull/29 is accepted.
-          const specialcharacters = owlbert.replace(
-            'name=owlbert.png;',
-            `name=${encodeURIComponent('owlbert (1).png')};`
-          );
-
-          const fixture = new Oas(multipartFormData);
-          const har = oasToHar(fixture, fixture.operation('/anything', 'post'), {
-            body: { orderId: 12345, userId: 67890, documentFile: specialcharacters },
-          });
-
-          expect(har.log.entries[0].request.headers).toStrictEqual([
-            { name: 'Content-Type', value: 'multipart/form-data' },
-          ]);
-
-          expect(har.log.entries[0].request.postData).toStrictEqual({
-            mimeType: 'multipart/form-data',
-            params: [
-              { name: 'orderId', value: '12345' },
-              { name: 'userId', value: '67890' },
-              {
-                contentType: 'image/png',
-                fileName: encodeURIComponent('owlbert (1).png'),
-                name: 'documentFile',
-                value: specialcharacters,
-              },
-            ],
-          });
-        });
-
-        it('should handle a multipart/form-data request where files are in an array', () => {
-          const fixture = new Oas(multipartFormDataArrayOfFiles);
-          const har = oasToHar(fixture, fixture.operation('/anything', 'post'), {
-            body: {
-              documentFiles: [owlbert, owlbert],
-            },
-          });
-
-          expect(har.log.entries[0].request.postData).toStrictEqual({
-            mimeType: 'multipart/form-data',
-            params: [
-              {
-                name: 'documentFiles',
-                value: JSON.stringify([owlbert, owlbert]),
-              },
-            ],
-          });
-        });
-      });
-
-      describe('image/png', () => {
-        it('should handle a image/png request body', async () => {
-          let owlbert = await datauri(path.join(__dirname, '__fixtures__', 'owlbert.png'));
-
-          // Doing this manually for now until when/if https://github.com/data-uri/datauri/pull/29 is accepted.
-          owlbert = owlbert.replace(';base64', `;name=${encodeURIComponent('owlbert.png')};base64`);
-
-          const har = oasToHar(
-            oas,
-            {
-              path: '/',
-              method: 'post',
-              responses: {
-                200: {
-                  description: 'OK',
-                },
-              },
-              requestBody: {
-                content: {
-                  'image/png': {
-                    schema: {
-                      type: 'string',
-                      format: 'binary',
-                    },
-                  },
-                },
-              },
-            },
-            { body: owlbert }
-          );
-
-          await expect(har).toBeAValidHAR();
-
-          // The `postData` contents here should be the data URL of the image for a couple reasons:
-          //
-          //  1. The HAR spec doesn't have support for covering a case where you're making a PUT request to an endpoint
-          //    with the contents of a file, eg. `curl -T filename.png`. Since there's no parameter name, as this is
-          //    the entire content of the payload body, we can't promote this up to `postData.params`.
-          //  2. Since the HAR spec doesn't have support for this, neither does the `httpsnippet` module, which we
-          //    couple with this library to generate code snippets. Since that doesn't have support for `curl -T
-          //    filename.png` cases, the only thing we can do is just set the data URL of the file as the content of
-          //    `postData.text`.
-          //
-          //  It's less than ideal, and code snippets for these kinds of operations are going to be extremely ugly, but
-          //  there isn't anything we can do about it.
-          expect(har.log.entries[0].request.postData.mimeType).toBe('image/png');
-          expect(har.log.entries[0].request.postData.text).toBe(`${owlbert}`);
-        });
-      });
-    });
-
-    describe('format: `json`', () => {
-      it('should work for refs that require a lookup', () => {
-        expect(
-          oasToHar(
-            new Oas({
-              components: {
-                requestBodies: {
-                  schema: {
-                    content: {
-                      'application/json': {
-                        schema: {
-                          string: 'object',
-                          properties: { a: { type: 'string', format: 'json' } },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            }),
-            {
-              path: '/body',
-              method: 'get',
-              requestBody: {
-                $ref: '#/components/requestBodies/schema',
-              },
-            },
-            { body: { a: '{ "b": 1 }' } }
-          ).log.entries[0].request.postData.text
-        ).toBe(JSON.stringify({ a: JSON.parse('{ "b": 1 }') }));
-      });
-
-      it('should leave invalid JSON as strings', () => {
-        expect(
-          oasToHar(
-            oas,
-            {
-              path: '/body',
-              method: 'post',
-              requestBody: {
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'object',
-                      required: ['a'],
-                      properties: {
-                        a: {
-                          type: 'string',
-                          format: 'json',
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            { body: { a: '{ "b": invalid json' } }
-          ).log.entries[0].request.postData.text
-        ).toBe(JSON.stringify({ a: '{ "b": invalid json' }));
-      });
-
-      it('should parse valid arbitrary JSON request bodies', () => {
-        expect(
-          oasToHar(
-            oas,
-            {
-              path: '/body',
-              method: 'post',
-              requestBody: {
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'string',
-                      format: 'json',
-                    },
-                  },
-                },
-              },
-            },
-            { body: '{ "a": { "b": "valid json" } }' }
-          ).log.entries[0].request.postData.text
-        ).toBe('{"a":{"b":"valid json"}}');
-      });
-
-      it('should parse invalid arbitrary JSON request bodies as strings', () => {
-        expect(
-          oasToHar(
-            oas,
-            {
-              path: '/body',
-              method: 'post',
-              requestBody: {
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'string',
-                      format: 'json',
-                    },
-                  },
-                },
-              },
-            },
-            { body: '{ "a": { "b": "valid json } }' }
-          ).log.entries[0].request.postData.text
-        ).toBe(JSON.stringify('{ "a": { "b": "valid json } }'));
-      });
-
-      it('should parse valid JSON as an object', () => {
-        expect(
-          oasToHar(
-            oas,
-            {
-              path: '/body',
-              method: 'post',
-              requestBody: {
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'object',
-                      required: ['a'],
-                      properties: {
-                        a: {
-                          type: 'string',
-                          format: 'json',
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            { body: { a: '{ "b": "valid json" }' } }
-          ).log.entries[0].request.postData.text
-        ).toBe(JSON.stringify({ a: JSON.parse('{ "b": "valid json" }') }));
-      });
-
-      it('should parse one valid JSON format even if another is invalid', () => {
-        expect(
-          oasToHar(
-            oas,
-            {
-              path: '/body',
-              method: 'post',
-              requestBody: {
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'object',
-                      required: ['a'],
-                      properties: {
-                        a: {
-                          type: 'string',
-                          format: 'json',
-                        },
-                        b: {
-                          type: 'string',
-                          format: 'json',
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            { body: { a: '{ "z": "valid json" }', b: 'invalid json' } }
-          ).log.entries[0].request.postData.text
-        ).toBe(JSON.stringify({ a: { z: 'valid json' }, b: 'invalid json' }));
-      });
-
-      it('should parse one valid JSON format even if another is left empty', () => {
-        expect(
-          oasToHar(
-            oas,
-            {
-              path: '/body',
-              method: 'post',
-              requestBody: {
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'object',
-                      required: ['a'],
-                      properties: {
-                        a: {
-                          type: 'string',
-                          format: 'json',
-                        },
-                        b: {
-                          type: 'string',
-                          format: 'json',
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            { body: { a: '{ "z": "valid json" }', b: undefined } }
-          ).log.entries[0].request.postData.text
-        ).toBe(JSON.stringify({ a: { z: 'valid json' }, b: undefined }));
-      });
-
-      it('should leave user specified empty object JSON alone', () => {
-        expect(
-          oasToHar(
-            oas,
-            {
-              path: '/body',
-              method: 'post',
-              requestBody: {
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'object',
-                      required: ['a'],
-                      properties: {
-                        a: {
-                          type: 'string',
-                          format: 'json',
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            { body: { a: '{}' } }
-          ).log.entries[0].request.postData.text
-        ).toBe(JSON.stringify({ a: {} }));
-      });
-    });
-  });
-
-  describe('formData values', () => {
-    it('should not add on empty unrequired values', () => {
-      expect(
-        oasToHar(oas, {
-          path: '/body',
-          method: 'get',
-          requestBody: {
-            content: {
-              'application/x-www-form-urlencoded': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    a: {
-                      type: 'string',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        }).log.entries[0].request.postData
-      ).toBeUndefined();
-    });
-
-    // TODO extensions[SEND_DEFAULTS]
-    it.skip('should set defaults if no value provided but is required', () => {
-      expect(
-        oasToHar(oas, {
-          path: '/body',
-          method: 'get',
-          requestBody: {
-            content: {
-              'application/x-www-form-urlencoded': {
-                schema: {
-                  type: 'object',
-                  required: ['a'],
-                  properties: {
-                    a: {
-                      type: 'string',
-                    },
-                  },
-                },
-                example: { a: 'value' },
-              },
-            },
-          },
-        }).log.entries[0].request.postData.text
-      ).toBe(JSON.stringify({ a: 'value' }));
-    });
-
-    it('should not add undefined formData into postData', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/x-www-form-urlencoded': {
-                  schema: {
-                    type: 'object',
-                    properties: {
-                      foo: {
-                        type: 'string',
-                      },
-                      bar: {
-                        type: 'string',
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { formData: { foo: undefined, bar: undefined } }
-        ).log.entries[0].request.postData
-      ).toBeUndefined();
-    });
-
-    it('should pass in value if one is set and prioritise provided values', () => {
-      expect(
-        oasToHar(
-          oas,
-          {
-            path: '/body',
-            method: 'get',
-            requestBody: {
-              content: {
-                'application/x-www-form-urlencoded': {
-                  schema: {
-                    type: 'object',
-                    required: ['a'],
-                    properties: {
-                      a: {
-                        type: 'string',
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          { formData: { a: 'test', b: [1, 2, 3] } }
-        ).log.entries[0].request.postData.params
-      ).toStrictEqual([
-        { name: 'a', value: 'test' },
-        { name: 'b', value: '1,2,3' },
-      ]);
-    });
-
-    it('should support nested objects', () => {
-      // eslint-disable-next-line global-require
-      const spec = new Oas(require('./__fixtures__/formData-nested-object.json'));
-      const operation = spec.operation('/anything', 'post');
-      const formData = {
-        id: 12345,
-        Request: {
-          MerchantId: 'buster',
-        },
-      };
-
-      const har = oasToHar(spec, operation, { formData });
-      expect(har.log.entries[0].request.postData.params).toStrictEqual([
-        { name: 'id', value: 12345 },
-        { name: 'Request', value: '{"MerchantId":"buster"}' },
-      ]);
-    });
-  });
-});
-
-describe('common parameters', () => {
-  const operation = {
-    ...commonParameters.paths['/anything/{id}'].post,
-    path: '/anything/{id}',
-    method: 'post',
-  };
-
-  it('should work for common parameters', async () => {
-    const har = oasToHar(new Oas(commonParameters), operation, {
-      path: { id: 1234 },
-      header: { 'x-extra-id': 'abcd' },
-      query: { limit: 10 },
-      cookie: { authtoken: 'password' },
-    });
-
-    await expect(har).toBeAValidHAR();
-    expect(har.log.entries[0].request).toStrictEqual({
-      bodySize: 0,
-      cookies: [{ name: 'authtoken', value: 'password' }],
-      headers: [{ name: 'x-extra-id', value: 'abcd' }],
-      headersSize: 0,
-      httpVersion: 'HTTP/1.1',
-      queryString: [{ name: 'limit', value: '10' }],
-      method: 'POST',
-      url: 'https://httpbin.org/anything/1234',
-    });
-  });
-
-  it('should not mutate the original pathOperation that was passed in', () => {
-    const existingCount = operation.parameters.length;
-
-    oasToHar(new Oas(commonParameters), operation, {
-      path: { id: 1234 },
-      header: { 'x-extra-id': 'abcd' },
-      query: { limit: 10 },
-      cookie: { authtoken: 'password' },
-    });
-
-    expect(operation.parameters).toHaveLength(existingCount);
   });
 });
 
 describe('auth', () => {
   it('should work for header', () => {
-    expect(
-      oasToHar(
-        new Oas({
-          components: {
-            securitySchemes: {
-              'auth-header': {
-                type: 'apiKey',
-                name: 'x-auth-header',
-                in: 'header',
-              },
-            },
+    const spec = new Oas({
+      paths: {
+        '/security': {
+          get: {
+            security: [{ 'auth-header': [] }],
           },
-        }),
-        {
-          path: '/security',
-          method: 'get',
-          security: [{ 'auth-header': [] }],
         },
-        {},
-        {
-          'auth-header': 'value',
-        }
-      ).log.entries[0].request.headers
+      },
+      components: {
+        securitySchemes: {
+          'auth-header': {
+            type: 'apiKey',
+            name: 'x-auth-header',
+            in: 'header',
+          },
+        },
+      },
+    });
+
+    expect(
+      oasToHar(spec, spec.operation('/security', 'get'), {}, { 'auth-header': 'value' }).log.entries[0].request.headers
     ).toStrictEqual([
       {
         name: 'x-auth-header',
@@ -1668,24 +192,29 @@ describe('auth', () => {
   });
 
   it('should work for query', () => {
+    const spec = new Oas({
+      paths: {
+        '/security': {
+          get: {
+            security: [{ 'auth-query': [] }],
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          'auth-query': {
+            type: 'apiKey',
+            name: 'authQuery',
+            in: 'query',
+          },
+        },
+      },
+    });
+
     expect(
       oasToHar(
-        new Oas({
-          components: {
-            securitySchemes: {
-              'auth-query': {
-                type: 'apiKey',
-                name: 'authQuery',
-                in: 'query',
-              },
-            },
-          },
-        }),
-        {
-          path: '/security',
-          method: 'get',
-          security: [{ 'auth-query': [] }],
-        },
+        spec,
+        spec.operation('/security', 'get'),
         {},
         {
           'auth-query': 'value',
@@ -1700,24 +229,29 @@ describe('auth', () => {
   });
 
   it('should work for cookie', () => {
+    const spec = new Oas({
+      paths: {
+        '/security': {
+          get: {
+            security: [{ 'auth-cookie': [] }],
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          'auth-cookie': {
+            type: 'apiKey',
+            name: 'authCookie',
+            in: 'cookie',
+          },
+        },
+      },
+    });
+
     expect(
       oasToHar(
-        new Oas({
-          components: {
-            securitySchemes: {
-              'auth-cookie': {
-                type: 'apiKey',
-                name: 'authCookie',
-                in: 'cookie',
-              },
-            },
-          },
-        }),
-        {
-          path: '/security',
-          method: 'get',
-          security: [{ 'auth-cookie': [] }],
-        },
+        spec,
+        spec.operation('/security', 'get'),
         {},
         {
           'auth-cookie': 'value',
@@ -1732,29 +266,34 @@ describe('auth', () => {
   });
 
   it('should work for multiple (||)', () => {
+    const spec = new Oas({
+      paths: {
+        '/security': {
+          get: {
+            security: [{ 'auth-header': [] }, { 'auth-header2': [] }],
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          'auth-header': {
+            type: 'apiKey',
+            name: 'x-auth-header',
+            in: 'header',
+          },
+          'auth-header2': {
+            type: 'apiKey',
+            name: 'x-auth-header2',
+            in: 'header',
+          },
+        },
+      },
+    });
+
     expect(
       oasToHar(
-        new Oas({
-          components: {
-            securitySchemes: {
-              'auth-header': {
-                type: 'apiKey',
-                name: 'x-auth-header',
-                in: 'header',
-              },
-              'auth-header2': {
-                type: 'apiKey',
-                name: 'x-auth-header2',
-                in: 'header',
-              },
-            },
-          },
-        }),
-        {
-          path: '/security',
-          method: 'get',
-          security: [{ 'auth-header': [] }, { 'auth-header2': [] }],
-        },
+        spec,
+        spec.operation('/security', 'get'),
         {},
         {
           'auth-header': 'value',
@@ -1774,29 +313,34 @@ describe('auth', () => {
   });
 
   it('should work for multiple (&&)', () => {
+    const spec = new Oas({
+      paths: {
+        '/security': {
+          get: {
+            security: [{ 'auth-header': [], 'auth-header2': [] }],
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          'auth-header': {
+            type: 'apiKey',
+            name: 'x-auth-header',
+            in: 'header',
+          },
+          'auth-header2': {
+            type: 'apiKey',
+            name: 'x-auth-header2',
+            in: 'header',
+          },
+        },
+      },
+    });
+
     expect(
       oasToHar(
-        new Oas({
-          components: {
-            securitySchemes: {
-              'auth-header': {
-                type: 'apiKey',
-                name: 'x-auth-header',
-                in: 'header',
-              },
-              'auth-header2': {
-                type: 'apiKey',
-                name: 'x-auth-header2',
-                in: 'header',
-              },
-            },
-          },
-        }),
-        {
-          path: '/security',
-          method: 'get',
-          security: [{ 'auth-header': [], 'auth-header2': [] }],
-        },
+        spec,
+        spec.operation('/security', 'get'),
         {},
         {
           'auth-header': 'value',
@@ -1816,202 +360,48 @@ describe('auth', () => {
   });
 
   it('should not set non-existent values', () => {
-    expect(
-      oasToHar(
-        new Oas({
-          components: {
-            securitySchemes: {
-              'auth-header': {
-                type: 'apiKey',
-                name: 'x-auth-header',
-                in: 'header',
-              },
-            },
-          },
-        }),
-        {
-          path: '/security',
-          method: 'get',
-          security: [{ 'auth-header': [] }],
-        },
-        {},
-        {}
-      ).log.entries[0].request.headers
-    ).toStrictEqual([]);
-  });
-});
-
-describe('content-type & accept header', () => {
-  const operation = {
-    path: '/body',
-    method: 'get',
-    requestBody: {
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            required: ['a'],
-            properties: {
-              a: {
-                type: 'string',
-              },
-            },
-          },
-          example: { a: 'value' },
-        },
-      },
-    },
-  };
-
-  it('should be sent through if there are no body values but there is a requestBody', async () => {
-    let har = oasToHar(oas, operation, {});
-
-    await expect(har).toBeAValidHAR();
-    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
-
-    har = oasToHar(oas, operation, { query: { a: 1 } });
-    await expect(har).toBeAValidHAR();
-    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
-  });
-
-  it('should be sent through if there are any body values', async () => {
-    const har = oasToHar(oas, operation, { body: { a: 'test' } });
-
-    await expect(har).toBeAValidHAR();
-    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
-  });
-
-  it('should be sent through if there are any formData values', async () => {
-    const har = oasToHar(oas, operation, { formData: { a: 'test' } });
-    await expect(har).toBeAValidHAR();
-    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
-  });
-
-  it('should fetch the type from the first `requestBody.content` and first `responseBody.content` object', async () => {
-    const har = oasToHar(
-      oas,
-      {
-        path: '/body',
-        method: 'get',
-        requestBody: {
-          content: {
-            'text/xml': {
-              schema: {
-                type: 'object',
-                required: ['a'],
-                properties: {
-                  a: {
-                    type: 'string',
-                  },
-                },
-              },
-              example: { a: 'value' },
-            },
+    const spec = new Oas({
+      paths: {
+        '/security': {
+          get: {
+            security: [{ 'auth-header': [] }],
           },
         },
       },
-      { body: { a: 'test' } }
-    );
-
-    await expect(har).toBeAValidHAR();
-    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'text/xml' }]);
-    expect(har.log.entries[0].request.postData.mimeType).toBe('text/xml');
-  });
-
-  // Whether this is right or wrong, i'm not sure but this is what readme currently does
-  it('should prioritise json if it exists', async () => {
-    const har = oasToHar(
-      oas,
-      {
-        path: '/body',
-        method: 'get',
-        requestBody: {
-          content: {
-            'text/xml': {
-              schema: {
-                type: 'string',
-                required: ['a'],
-                properties: {
-                  a: {
-                    type: 'string',
-                  },
-                },
-              },
-              example: { a: 'value' },
-            },
-            'application/json': {
-              schema: {
-                type: 'object',
-                required: ['a'],
-                properties: {
-                  a: {
-                    type: 'string',
-                  },
-                },
-              },
-              example: { a: 'value' },
-            },
+      components: {
+        securitySchemes: {
+          'auth-header': {
+            type: 'apiKey',
+            name: 'x-auth-header',
+            in: 'header',
           },
         },
       },
-      { body: { a: 'test' } }
-    );
+    });
 
-    await expect(har).toBeAValidHAR();
-    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
-  });
-
-  it("should only add a content-type if one isn't already present", async () => {
-    const har = oasToHar(
-      new Oas({
-        'x-headers': [{ key: 'Content-Type', value: 'multipart/form-data' }],
-      }),
-      {
-        path: '/',
-        method: 'put',
-        requestBody: {
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                required: ['a'],
-                properties: {
-                  a: {
-                    type: 'string',
-                  },
-                },
-              },
-              example: { a: 'value' },
-            },
-          },
-        },
-      },
-      { body: { a: 'test' } }
-    );
-
-    await expect(har).toBeAValidHAR();
-
-    // `Content-Type: application/json` would normally appear here if there were no `x-headers`, but since there is
-    // we should default to that so as to we don't double up on Content-Type headers.
-    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'multipart/form-data' }]);
-
-    expect(har.log.entries[0].request.postData.mimeType).toBe('multipart/form-data');
+    const har = oasToHar(spec, spec.operation('/security', 'get'), {}, {});
+    expect(har.log.entries[0].request.headers).toStrictEqual([]);
   });
 });
 
 describe('x-headers', () => {
   it('should append any static headers to the request', () => {
-    expect(
-      oasToHar(
-        new Oas({
-          'x-headers': [
-            {
-              key: 'x-api-key',
-              value: '123456',
-            },
-          ],
-        })
-      ).log.entries[0].request.headers
-    ).toStrictEqual([{ name: 'x-api-key', value: '123456' }]);
+    const spec = new Oas({
+      paths: {
+        '/': {
+          post: {},
+        },
+      },
+      'x-headers': [
+        {
+          key: 'x-api-key',
+          value: '123456',
+        },
+      ],
+    });
+
+    expect(oasToHar(spec, spec.operation('/', 'post')).log.entries[0].request.headers).toStrictEqual([
+      { name: 'x-api-key', value: '123456' },
+    ]);
   });
 });

--- a/__tests__/parameters.test.js
+++ b/__tests__/parameters.test.js
@@ -1,0 +1,504 @@
+const Oas = require('oas').default;
+const oasToHar = require('../src');
+const toBeAValidHAR = require('jest-expect-har').default;
+
+const commonParameters = require('./__fixtures__/common-parameters.json');
+
+expect.extend({ toBeAValidHAR });
+
+test('should work for schemas that require a parameters lookup', () => {
+  const spec = new Oas({
+    paths: {
+      '/': {
+        get: {
+          parameters: [
+            {
+              $ref: '#/components/parameters/authorization',
+            },
+          ],
+        },
+      },
+    },
+    components: {
+      parameters: {
+        authorization: {
+          name: 'Authorization',
+          in: 'header',
+        },
+      },
+    },
+  });
+
+  const har = oasToHar(spec, spec.operation('/', 'get'), { header: { Authorization: 'test' } });
+
+  expect(har.log.entries[0].request.headers[0].value).toBe('test');
+});
+
+describe('path', () => {
+  it('should pass through unknown path params', () => {
+    const spec = new Oas({
+      paths: {
+        '/path-param/{id}': {
+          get: {},
+          post: {
+            parameters: [
+              {
+                name: 'something-else',
+                in: 'path',
+                required: true,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(oasToHar(spec, spec.operation('/path-param/{id}', 'get')).log.entries[0].request.url).toBe(
+      'https://example.com/path-param/id'
+    );
+
+    expect(oasToHar(spec, spec.operation('/path-param/{id}', 'post')).log.entries[0].request.url).toBe(
+      'https://example.com/path-param/id'
+    );
+  });
+
+  it.each([
+    [
+      'should not error if empty object passed in for values',
+      {
+        parameters: [{ name: 'id', in: 'path', required: true }],
+      },
+      {},
+      'https://example.com/path-param/id',
+    ],
+    [
+      'should use default if no value',
+      {
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { default: '123' } }],
+      },
+      {},
+      'https://example.com/path-param/123',
+    ],
+    [
+      'should add path values to the url',
+      {
+        parameters: [{ name: 'id', in: 'path', required: true }],
+      },
+      { path: { id: '456' } },
+      'https://example.com/path-param/456',
+    ],
+    [
+      'should add falsy values to the url',
+      {
+        parameters: [{ name: 'id', in: 'path', required: true }],
+      },
+      { path: { id: 0 } },
+      'https://example.com/path-param/0',
+    ],
+  ])('%s', async (_, operation, formData, expectedUrl) => {
+    const spec = new Oas({
+      paths: {
+        '/path-param/{id}': {
+          get: operation,
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/path-param/{id}', 'get'), formData);
+    await expect(har).toBeAValidHAR();
+
+    expect(har.log.entries[0].request.url).toStrictEqual(expectedUrl);
+  });
+});
+
+describe('query', () => {
+  it.each([
+    [
+      'should not add on empty unrequired values',
+      {
+        parameters: [{ name: 'a', in: 'query' }],
+      },
+    ],
+    [
+      'should not add the parameter name as a value if required but missing',
+      {
+        parameters: [{ name: 'a', in: 'query', required: true }],
+      },
+    ],
+    [
+      'should set defaults if no value provided but is required',
+      {
+        parameters: [{ name: 'a', in: 'query', required: true, schema: { default: 'value' } }],
+      },
+      {},
+      [{ name: 'a', value: 'value' }],
+    ],
+    [
+      'should pass in value if one is set and prioritise provided values',
+      {
+        parameters: [{ name: 'a', in: 'query', required: true, schema: { default: 'value' } }],
+      },
+      { query: { a: 'test' } },
+      [{ name: 'a', value: 'test' }],
+    ],
+    [
+      'should add falsy values to the querystring',
+      {
+        parameters: [{ name: 'id', in: 'query' }],
+      },
+      { query: { id: 0 } },
+      [{ name: 'id', value: '0' }],
+    ],
+    [
+      'should handle null array values',
+      {
+        parameters: [{ name: 'id', in: 'query' }],
+      },
+      { query: { id: [null, null] } },
+      [{ name: 'id', value: '&id=' }],
+    ],
+    [
+      'should handle null values',
+      {
+        parameters: [{ name: 'id', in: 'query' }],
+      },
+      { query: { id: null } },
+      [{ name: 'id', value: 'null' }],
+    ],
+    [
+      'should handle null default values',
+      {
+        parameters: [
+          {
+            name: 'id',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              default: [null, null],
+            },
+          },
+        ],
+      },
+      { query: {} },
+      [{ name: 'id', value: '&id=' }],
+    ],
+  ])('%s', async (_, operation = {}, formData = {}, expectedQueryString = []) => {
+    const spec = new Oas({
+      paths: {
+        '/query': {
+          get: operation,
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/query', 'get'), formData);
+    await expect(har).toBeAValidHAR();
+
+    expect(har.log.entries[0].request.queryString).toStrictEqual(expectedQueryString);
+  });
+
+  describe('URI encoding', () => {
+    const spec = new Oas({
+      servers: [{ url: 'https://httpbin.org/' }],
+      paths: {
+        '/anything': {
+          get: {
+            parameters: [
+              { name: 'stringPound', in: 'query', schema: { type: 'string' } },
+              { name: 'stringPound2', in: 'query', schema: { type: 'string' } },
+              { name: 'stringHash', in: 'query', schema: { type: 'string' } },
+              { name: 'stringArray', in: 'query', schema: { type: 'string' } },
+              { name: 'stringWeird', in: 'query', schema: { type: 'string' } },
+              { name: 'array', in: 'query', schema: { type: 'array', items: { type: 'string' } } },
+            ],
+          },
+        },
+      },
+    });
+
+    it('should encode query parameters', async () => {
+      const formData = {
+        query: {
+          stringPound: 'something&nothing=true',
+          stringHash: 'hash#data',
+          stringArray: 'where[4]=10',
+          stringWeird: 'properties["$email"] == "testing"',
+          array: [
+            encodeURIComponent('something&nothing=true'), // This is already encoded so it shouldn't be double encoded.
+            'nothing&something=false',
+            'another item',
+          ],
+        },
+      };
+
+      const operation = spec.operation('/anything', 'get');
+
+      const har = oasToHar(spec, operation, formData);
+      await expect(har).toBeAValidHAR();
+
+      expect(har.log.entries[0].request.queryString).toStrictEqual([
+        { name: 'stringPound', value: 'something%26nothing%3Dtrue' },
+        { name: 'stringHash', value: 'hash%23data' },
+        { name: 'stringArray', value: 'where%5B4%5D%3D10' },
+        {
+          name: 'stringWeird',
+          value: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
+        },
+        { name: 'array', value: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item' },
+      ]);
+    });
+
+    it('should not double encode query parameters that are already encoded', async () => {
+      const formData = {
+        query: {
+          stringPound: encodeURIComponent('something&nothing=true'),
+          stringHash: encodeURIComponent('hash#data'),
+          stringArray: encodeURIComponent('where[4]=10'),
+          stringWeird: encodeURIComponent('properties["$email"] == "testing"'),
+          array: [
+            'something&nothing=true', // Should still encode this one eventhrough the others are already encoded.
+            encodeURIComponent('nothing&something=false'),
+            encodeURIComponent('another item'),
+          ],
+        },
+      };
+
+      const operation = spec.operation('/anything', 'get');
+
+      const har = oasToHar(spec, operation, formData);
+      await expect(har).toBeAValidHAR();
+
+      expect(har.log.entries[0].request.queryString).toStrictEqual([
+        { name: 'stringPound', value: 'something%26nothing%3Dtrue' },
+        { name: 'stringHash', value: 'hash%23data' },
+        { name: 'stringArray', value: 'where%5B4%5D%3D10' },
+        {
+          name: 'stringWeird',
+          value: 'properties%5B%22%24email%22%5D%20%3D%3D%20%22testing%22',
+        },
+        { name: 'array', value: 'something%26nothing%3Dtrue&array=nothing%26something%3Dfalse&array=another%20item' },
+      ]);
+    });
+  });
+});
+
+describe('cookie', () => {
+  it.each([
+    [
+      'should not add on empty unrequired values',
+      {
+        parameters: [{ name: 'a', in: 'cookie' }],
+      },
+    ],
+    [
+      'should not add the parameter name as a value if required but missing',
+      {
+        parameters: [{ name: 'a', in: 'cookie', required: true }],
+      },
+    ],
+    [
+      'should set defaults if no value provided but is required',
+      {
+        parameters: [{ name: 'a', in: 'cookie', required: true, schema: { default: 'value' } }],
+      },
+      {},
+      [{ name: 'a', value: 'value' }],
+    ],
+    [
+      'should pass in value if one is set and prioritize provided values',
+      {
+        parameters: [{ name: 'a', in: 'cookie', required: true, schema: { default: 'value' } }],
+      },
+      { cookie: { a: 'test' } },
+      [{ name: 'a', value: 'test' }],
+    ],
+    [
+      'should add falsy values to the cookies',
+      {
+        parameters: [{ name: 'id', in: 'cookie' }],
+      },
+      { cookie: { id: 0 } },
+      [{ name: 'id', value: '0' }],
+    ],
+  ])('%s', async (_, operation = {}, formData = {}, expectedCookies = []) => {
+    const spec = new Oas({
+      paths: {
+        '/cookie': {
+          get: operation,
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/cookie', 'get'), formData);
+    await expect(har).toBeAValidHAR();
+
+    expect(har.log.entries[0].request.cookies).toStrictEqual(expectedCookies);
+  });
+});
+
+describe('header', () => {
+  it.each([
+    [
+      'should not add on empty unrequired values',
+      {
+        parameters: [{ name: 'a', in: 'header' }],
+      },
+    ],
+    [
+      'should not add the parameter name as a value if required but missing',
+      {
+        parameters: [{ name: 'a', in: 'header', required: true }],
+      },
+    ],
+    [
+      'should set defaults if no value provided but is required',
+      {
+        parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
+      },
+      {},
+      [{ name: 'a', value: 'value' }],
+    ],
+    [
+      'should pass in value if one is set and prioritise provided values',
+      {
+        parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
+      },
+      { header: { a: 'test' } },
+      [{ name: 'a', value: 'test' }],
+    ],
+    [
+      'should pass accept header if endpoint expects a content back from response',
+      {
+        parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
+        responses: {
+          200: {
+            content: {
+              'application/xml': { type: 'array' },
+              'application/json': { type: 'array' },
+            },
+          },
+        },
+      },
+      {},
+      [
+        { name: 'Accept', value: 'application/xml' },
+        { name: 'a', value: 'value' },
+      ],
+    ],
+    [
+      'should only add one accept header',
+      {
+        responses: {
+          200: {
+            content: {
+              'application/xml': {},
+            },
+          },
+          400: {
+            content: {
+              'application/json': {},
+            },
+          },
+        },
+      },
+      {},
+      [{ name: 'Accept', value: 'application/xml' }],
+    ],
+    [
+      'should only receive one accept header if specified in values',
+      {
+        parameters: [{ name: 'Accept', in: 'header' }],
+        responses: {
+          200: {
+            content: {
+              'application/json': {},
+              'application/xml': {},
+            },
+          },
+        },
+      },
+      { header: { Accept: 'application/xml' } },
+      [{ name: 'Accept', value: 'application/xml' }],
+    ],
+    [
+      'should add accept header if specified in formdata',
+      {
+        responses: {
+          200: {
+            content: {
+              'application/json': {},
+              'application/xml': {},
+            },
+          },
+        },
+      },
+      { header: { Accept: 'application/xml' } },
+      [{ name: 'Accept', value: 'application/xml' }],
+    ],
+    [
+      'should add falsy values to the headers',
+      {
+        parameters: [{ name: 'id', in: 'header' }],
+      },
+      { header: { id: 0 } },
+      [{ name: 'id', value: '0' }],
+    ],
+  ])('%s', async (_, operation = {}, formData = {}, expectedHeaders = []) => {
+    const spec = new Oas({
+      paths: {
+        '/header': {
+          post: operation,
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/header', 'post'), formData);
+    await expect(har).toBeAValidHAR();
+
+    expect(har.log.entries[0].request.headers).toStrictEqual(expectedHeaders);
+  });
+});
+
+describe('common parameters', () => {
+  it('should work for common parameters', async () => {
+    const spec = new Oas(commonParameters);
+    const har = oasToHar(spec, spec.operation('/anything/{id}', 'post'), {
+      path: { id: 1234 },
+      header: { 'x-extra-id': 'abcd' },
+      query: { limit: 10 },
+      cookie: { authtoken: 'password' },
+    });
+
+    await expect(har).toBeAValidHAR();
+    expect(har.log.entries[0].request).toStrictEqual({
+      bodySize: 0,
+      cookies: [{ name: 'authtoken', value: 'password' }],
+      headers: [{ name: 'x-extra-id', value: 'abcd' }],
+      headersSize: 0,
+      httpVersion: 'HTTP/1.1',
+      queryString: [{ name: 'limit', value: '10' }],
+      method: 'POST',
+      url: 'https://httpbin.org/anything/1234',
+    });
+  });
+
+  it('should not mutate the original operation that was passed in', () => {
+    const spec = new Oas(commonParameters);
+    const operation = spec.operation('/anything/{id}', 'post');
+
+    const existingCount = operation.schema.parameters.length;
+
+    oasToHar(spec, operation, {
+      path: { id: 1234 },
+      header: { 'x-extra-id': 'abcd' },
+      query: { limit: 10 },
+      cookie: { authtoken: 'password' },
+    });
+
+    expect(operation.schema.parameters).toHaveLength(existingCount);
+  });
+});

--- a/__tests__/requestBody.test.js
+++ b/__tests__/requestBody.test.js
@@ -1,0 +1,1011 @@
+const Oas = require('oas').default;
+const extensions = require('@readme/oas-extensions');
+const path = require('path');
+const datauri = require('datauri');
+const oasToHar = require('../src');
+const toBeAValidHAR = require('jest-expect-har').default;
+
+const multipartFormData = require('./__fixtures__/multipart-form-data.json');
+const multipartFormDataArrayOfFiles = require('./__fixtures__/multipart-form-data/array-of-files.json');
+const requestBodyRawBody = require('./__fixtures__/requestBody-raw_body.json');
+
+expect.extend({ toBeAValidHAR });
+
+describe('`body` data handling', () => {
+  it('should not add on empty unrequired values', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(oasToHar(spec, spec.operation('/requestBody', 'post')).log.entries[0].request.postData).toBeUndefined();
+  });
+
+  it('should pass in value if one is set and prioritise provided values', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['a'],
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { a: 'test' } });
+
+    expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify({ a: 'test' }));
+  });
+
+  it('should return nothing for undefined body property', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { a: undefined } });
+
+    expect(har.log.entries[0].request.postData.text).toBeUndefined();
+  });
+
+  it('should work for schemas that require a lookup', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              $ref: '#/components/requestBodies/schema',
+            },
+          },
+        },
+      },
+      components: {
+        requestBodies: {
+          schema: {
+            content: {
+              'application/json': {
+                schema: { type: 'object', properties: { a: { type: 'integer' } } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { a: 123 } });
+
+    expect(har.log.entries[0].request.postData.text).toStrictEqual(JSON.stringify({ a: 123 }));
+  });
+
+  it('should work for top level primitives', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+          put: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'integer',
+                    format: 'int64',
+                  },
+                },
+              },
+            },
+          },
+          patch: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'boolean',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    let har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: 'string' });
+    expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify('string'));
+
+    har = oasToHar(spec, spec.operation('/requestBody', 'put'), { body: 123 });
+    expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify(123));
+
+    har = oasToHar(spec, spec.operation('/requestBody', 'patch'), { body: true });
+    expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify(true));
+  });
+
+  it('should work for top level falsy primitives', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+          put: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'integer',
+                    format: 'int64',
+                  },
+                },
+              },
+            },
+          },
+          patch: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'boolean',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    let har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: '' });
+    expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify(''));
+
+    har = oasToHar(spec, spec.operation('/requestBody', 'put'), { body: 0 });
+    expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify(0));
+
+    har = oasToHar(spec, spec.operation('/requestBody', 'patch'), { body: false });
+    expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify(false));
+  });
+
+  it('should not include objects with undefined sub properties', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      a: {
+                        type: 'object',
+                        properties: {
+                          b: {
+                            type: 'string',
+                          },
+                          c: {
+                            type: 'object',
+                            properties: {
+                              d: {
+                                type: 'string',
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/requestBody', 'post'), {
+      body: { a: { b: undefined, c: { d: undefined } } },
+    });
+
+    expect(har.log.entries[0].request.postData.text).toBeUndefined();
+  });
+
+  // When we first render the form, `formData.body` is `undefined` until something is typed into the form. When using
+  // anyOf/oneOf if we change the schema before typing anything into the form, then `onChange` is fired with `undefined`
+  // which causes this to error.
+  it('should not error if `formData.body` is undefined', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: undefined });
+    expect(har.log.entries[0].request.postData).toBeUndefined();
+  });
+
+  describe('`RAW_BODY`-named properties', () => {
+    it('should work for RAW_BODY primitives', () => {
+      const spec = new Oas(requestBodyRawBody);
+      const har = oasToHar(spec, spec.operation('/primitive', 'post'), { body: { RAW_BODY: 'test' } });
+
+      expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify('test'));
+    });
+
+    it('should return empty for falsy RAW_BODY primitives', () => {
+      const spec = new Oas(requestBodyRawBody);
+      const har = oasToHar(spec, spec.operation('/primitive', 'post'), { body: { RAW_BODY: '' } });
+
+      expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify(''));
+    });
+
+    it('should work for RAW_BODY json', () => {
+      const spec = new Oas(requestBodyRawBody);
+      const har = oasToHar(spec, spec.operation('/json', 'post'), { body: { RAW_BODY: '{ "a": 1 }' } });
+
+      expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify({ a: 1 }));
+    });
+
+    it('should work for RAW_BODY objects', () => {
+      const spec = new Oas(requestBodyRawBody);
+      const har = oasToHar(spec, spec.operation('/objects', 'post'), { body: { RAW_BODY: { a: 'test' } } });
+
+      expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify({ a: 'test' }));
+    });
+
+    it('should return empty for RAW_BODY objects', () => {
+      const spec = new Oas(requestBodyRawBody);
+      const har = oasToHar(spec, spec.operation('/objects', 'post'), { body: { RAW_BODY: {} } });
+
+      expect(har.log.entries[0].request.postData.text).toBeUndefined();
+    });
+  });
+
+  describe('content types', () => {
+    describe('multipart/form-data', () => {
+      let owlbert;
+
+      beforeAll(async () => {
+        owlbert = await datauri(path.join(__dirname, '__fixtures__', 'owlbert.png'));
+
+        // Doing this manually for now until when/if https://github.com/data-uri/datauri/pull/29 is accepted.
+        owlbert = owlbert.replace(';base64', `;name=${encodeURIComponent('owlbert.png')};base64`);
+      });
+
+      it('should handle multipart/form-data request bodies', () => {
+        const fixture = new Oas(multipartFormData);
+        const har = oasToHar(fixture, fixture.operation('/anything', 'post'), {
+          body: { orderId: 12345, userId: 67890, documentFile: owlbert },
+        });
+
+        expect(har.log.entries[0].request.headers).toStrictEqual([
+          { name: 'Content-Type', value: 'multipart/form-data' },
+        ]);
+
+        expect(har.log.entries[0].request.postData).toStrictEqual({
+          mimeType: 'multipart/form-data',
+          params: [
+            { name: 'orderId', value: '12345' },
+            { name: 'userId', value: '67890' },
+            {
+              contentType: 'image/png',
+              fileName: 'owlbert.png',
+              name: 'documentFile',
+              value: owlbert,
+            },
+          ],
+        });
+      });
+
+      it('should handle multipart/form-data request bodies where the filename contains parentheses', () => {
+        // Doing this manually for now until when/if https://github.com/data-uri/datauri/pull/29 is accepted.
+        const specialcharacters = owlbert.replace(
+          'name=owlbert.png;',
+          `name=${encodeURIComponent('owlbert (1).png')};`
+        );
+
+        const fixture = new Oas(multipartFormData);
+        const har = oasToHar(fixture, fixture.operation('/anything', 'post'), {
+          body: { orderId: 12345, userId: 67890, documentFile: specialcharacters },
+        });
+
+        expect(har.log.entries[0].request.headers).toStrictEqual([
+          { name: 'Content-Type', value: 'multipart/form-data' },
+        ]);
+
+        expect(har.log.entries[0].request.postData).toStrictEqual({
+          mimeType: 'multipart/form-data',
+          params: [
+            { name: 'orderId', value: '12345' },
+            { name: 'userId', value: '67890' },
+            {
+              contentType: 'image/png',
+              fileName: encodeURIComponent('owlbert (1).png'),
+              name: 'documentFile',
+              value: specialcharacters,
+            },
+          ],
+        });
+      });
+
+      it('should handle a multipart/form-data request where files are in an array', () => {
+        const fixture = new Oas(multipartFormDataArrayOfFiles);
+        const har = oasToHar(fixture, fixture.operation('/anything', 'post'), {
+          body: {
+            documentFiles: [owlbert, owlbert],
+          },
+        });
+
+        expect(har.log.entries[0].request.postData).toStrictEqual({
+          mimeType: 'multipart/form-data',
+          params: [
+            {
+              name: 'documentFiles',
+              value: JSON.stringify([owlbert, owlbert]),
+            },
+          ],
+        });
+      });
+    });
+
+    describe('image/png', () => {
+      it('should handle a image/png request body', async () => {
+        let owlbert = await datauri(path.join(__dirname, '__fixtures__', 'owlbert.png'));
+
+        // Doing this manually for now until when/if https://github.com/data-uri/datauri/pull/29 is accepted.
+        owlbert = owlbert.replace(';base64', `;name=${encodeURIComponent('owlbert.png')};base64`);
+
+        const spec = new Oas({
+          paths: {
+            '/image': {
+              post: {
+                requestBody: {
+                  content: {
+                    'image/png': {
+                      schema: {
+                        type: 'string',
+                        format: 'binary',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        const har = oasToHar(spec, spec.operation('/image', 'post'), { body: owlbert });
+        await expect(har).toBeAValidHAR();
+
+        // The `postData` contents here should be the data URL of the image for a couple reasons:
+        //
+        //  1. The HAR spec doesn't have support for covering a case where you're making a PUT request to an endpoint
+        //    with the contents of a file, eg. `curl -T filename.png`. Since there's no parameter name, as this is
+        //    the entire content of the payload body, we can't promote this up to `postData.params`.
+        //  2. Since the HAR spec doesn't have support for this, neither does the `httpsnippet` module, which we
+        //    couple with this library to generate code snippets. Since that doesn't have support for `curl -T
+        //    filename.png` cases, the only thing we can do is just set the data URL of the file as the content of
+        //    `postData.text`.
+        //
+        //  It's less than ideal, and code snippets for these kinds of operations are going to be extremely ugly, but
+        //  there isn't anything we can do about it.
+        expect(har.log.entries[0].request.postData.mimeType).toBe('image/png');
+        expect(har.log.entries[0].request.postData.text).toBe(`${owlbert}`);
+      });
+    });
+  });
+
+  describe('format: `json`', () => {
+    it('should work for refs that require a lookup', async () => {
+      const spec = new Oas({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                $ref: '#/components/requestBodies/schema',
+              },
+            },
+          },
+        },
+        components: {
+          requestBodies: {
+            schema: {
+              content: {
+                'application/json': {
+                  schema: {
+                    string: 'object',
+                    properties: { a: { type: 'string', format: 'json' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      await spec.dereference();
+
+      const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { a: '{ "b": 1 }' } });
+      expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify({ a: JSON.parse('{ "b": 1 }') }));
+    });
+
+    it('should leave invalid JSON as strings', () => {
+      const spec = new Oas({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      required: ['a'],
+                      properties: {
+                        a: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { a: '{ "b": invalid json' } });
+      expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify({ a: '{ "b": invalid json' }));
+    });
+
+    it('should parse valid arbitrary JSON request bodies', () => {
+      const spec = new Oas({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                      format: 'json',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: '{ "a": { "b": "valid json" } }' });
+      expect(har.log.entries[0].request.postData.text).toBe('{"a":{"b":"valid json"}}');
+    });
+
+    it('should parse invalid arbitrary JSON request bodies as strings', () => {
+      const spec = new Oas({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                      format: 'json',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: '{ "a": { "b": "valid json } }' });
+      expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify('{ "a": { "b": "valid json } }'));
+    });
+
+    it('should parse valid JSON as an object', () => {
+      const spec = new Oas({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      required: ['a'],
+                      properties: {
+                        a: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { a: '{ "b": "valid json" }' } });
+      expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify({ a: JSON.parse('{ "b": "valid json" }') }));
+    });
+
+    it('should parse one valid JSON format even if another is invalid', () => {
+      const spec = new Oas({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      required: ['a'],
+                      properties: {
+                        a: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                        b: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const har = oasToHar(spec, spec.operation('/requestBody', 'post'), {
+        body: { a: '{ "z": "valid json" }', b: 'invalid json' },
+      });
+
+      expect(har.log.entries[0].request.postData.text).toBe(
+        JSON.stringify({ a: { z: 'valid json' }, b: 'invalid json' })
+      );
+    });
+
+    it('should parse one valid JSON format even if another is left empty', () => {
+      const spec = new Oas({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      required: ['a'],
+                      properties: {
+                        a: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                        b: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const har = oasToHar(spec, spec.operation('/requestBody', 'post'), {
+        body: { a: '{ "z": "valid json" }', b: undefined },
+      });
+
+      expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify({ a: { z: 'valid json' }, b: undefined }));
+    });
+
+    it('should leave user specified empty object JSON alone', () => {
+      const spec = new Oas({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      required: ['a'],
+                      properties: {
+                        a: {
+                          type: 'string',
+                          format: 'json',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { a: '{}' } });
+      expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify({ a: {} }));
+    });
+  });
+});
+
+describe('`formData` data handling', () => {
+  it('should not add on empty unrequired values', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(oasToHar(spec, spec.operation('/requestBody', 'post')).log.entries[0].request.postData).toBeUndefined();
+  });
+
+  it('should not add undefined formData into postData', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      foo: {
+                        type: 'string',
+                      },
+                      bar: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/requestBody', 'post'), {
+      formData: { foo: undefined, bar: undefined },
+    });
+
+    expect(har.log.entries[0].request.postData).toBeUndefined();
+  });
+
+  it('should pass in value if one is set and prioritise provided values', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    required: ['a'],
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { formData: { a: 'test', b: [1, 2, 3] } });
+    expect(har.log.entries[0].request.postData.params).toStrictEqual([
+      { name: 'a', value: 'test' },
+      { name: 'b', value: '1,2,3' },
+    ]);
+  });
+
+  it('should support nested objects', () => {
+    // eslint-disable-next-line global-require
+    const spec = new Oas(require('./__fixtures__/formData-nested-object.json'));
+    const operation = spec.operation('/anything', 'post');
+    const formData = {
+      id: 12345,
+      Request: {
+        MerchantId: 'buster',
+      },
+    };
+
+    const har = oasToHar(spec, operation, { formData });
+    expect(har.log.entries[0].request.postData.params).toStrictEqual([
+      { name: 'id', value: 12345 },
+      { name: 'Request', value: '{"MerchantId":"buster"}' },
+    ]);
+  });
+});
+
+describe('`content-type` and `accept` header', () => {
+  const spec = new Oas({
+    paths: {
+      '/requestBody': {
+        post: {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['a'],
+                  properties: {
+                    a: {
+                      type: 'string',
+                    },
+                  },
+                },
+                example: { a: 'value' },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  it('should be sent through if there are no body values but there is a requestBody', async () => {
+    let har = oasToHar(spec, spec.operation('/requestBody', 'post'), {});
+    await expect(har).toBeAValidHAR();
+
+    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
+
+    har = oasToHar(spec, spec.operation('/requestBody', 'post'), { query: { a: 1 } });
+    await expect(har).toBeAValidHAR();
+
+    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
+  });
+
+  it('should be sent through if there are any body values', async () => {
+    const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { a: 'test' } });
+    await expect(har).toBeAValidHAR();
+
+    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
+  });
+
+  it('should be sent through if there are any formData values', async () => {
+    const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { formData: { a: 'test' } });
+    await expect(har).toBeAValidHAR();
+
+    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
+  });
+
+  it('should fetch the type from the first `requestBody.content` and first `responseBody.content` object', async () => {
+    const contentSpec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'text/xml': {
+                  schema: {
+                    type: 'object',
+                    required: ['a'],
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                  example: { a: 'value' },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const har = oasToHar(contentSpec, contentSpec.operation('/requestBody', 'post'), { body: { a: 'test' } });
+    await expect(har).toBeAValidHAR();
+
+    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'text/xml' }]);
+    expect(har.log.entries[0].request.postData.mimeType).toBe('text/xml');
+  });
+
+  // Whether this is right or wrong, i'm not sure but this is what readme currently does
+  it('should prioritise json if it exists', async () => {
+    const contentSpec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'text/xml': {
+                  schema: {
+                    type: 'string',
+                    required: ['a'],
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                  example: { a: 'value' },
+                },
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['a'],
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                  example: { a: 'value' },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const har = oasToHar(contentSpec, contentSpec.operation('/requestBody', 'post'), { body: { a: 'test' } });
+    await expect(har).toBeAValidHAR();
+
+    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'application/json' }]);
+  });
+
+  it("should only add a content-type if one isn't already present", async () => {
+    const contentSpec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['a'],
+                    properties: {
+                      a: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                  example: { a: 'value' },
+                },
+              },
+            },
+          },
+        },
+      },
+      'x-readme': {
+        [extensions.HEADERS]: [{ key: 'Content-Type', value: 'multipart/form-data' }],
+      },
+    });
+
+    const har = oasToHar(contentSpec, contentSpec.operation('/requestBody', 'post'), { body: { a: 'test' } });
+    await expect(har).toBeAValidHAR();
+
+    // `Content-Type: application/json` would normally appear here if there were no `x-readme.headers`, but since there
+    // is we should default to that so as to we don't double up on Content-Type headers.
+    expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'Content-Type', value: 'multipart/form-data' }]);
+
+    expect(har.log.entries[0].request.postData.mimeType).toBe('multipart/form-data');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@readme/oas-extensions": "^14.0.0",
-        "oas": "^17.1.0",
+        "oas": "^17.3.2",
         "parse-data-url": "^4.0.1"
       },
       "devDependencies": {
@@ -1292,6 +1292,14 @@
         "node": ">=10.10.0"
       }
     },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
+      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA==",
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
@@ -2501,12 +2509,13 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.1.1.tgz",
-      "integrity": "sha512-3FmPBv2fYj2Qgvg8Qq3wEL7CxLPA6nwkVGafdEfS/85DIUx9z0iZcHu48no/l0HOk9PCKUDqpinN6bTtLxD0og==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.3.0.tgz",
+      "integrity": "sha512-9yDff0hkbJJ/KaT+pVdHi6+2FeHsaImOz/LGqYp/auMBFSzUcP+y2kcte0pHrnePHgPp+Lt5H91RS5unwM++6Q==",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
         "@babel/runtime": "^7.16.0",
+        "@humanwhocodes/momoa": "^2.0.2",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -2617,6 +2626,33 @@
         "prettier": "^2.0.2"
       }
     },
+    "node_modules/@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@readme/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/@readme/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@readme/oas-examples": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
@@ -2636,15 +2672,15 @@
       }
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.1.0.tgz",
-      "integrity": "sha512-gGoZk7yZ1MIFaFYgqm6HVaXgeIs4hCvVLys801llZF9CcXXE4DWBrpUk1VgU94cA08th6GWBLcMHiREr65Cw1A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
+      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^1.1.0",
+        "@readme/json-schema-ref-parser": "^1.0.0",
         "ajv": "^8.6.3",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
@@ -2653,21 +2689,10 @@
         "openapi-types": ">=7"
       }
     },
-    "node_modules/@readme/openapi-parser/node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "0.0.0-dev",
-      "resolved": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
     "node_modules/@readme/openapi-parser/node_modules/ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -2690,22 +2715,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@readme/openapi-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/@readme/openapi-parser/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@readme/openapi-parser/node_modules/json-schema-traverse": {
@@ -4544,11 +4553,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-get-iterator/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -6923,6 +6927,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -10923,11 +10932,12 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.6.tgz",
-      "integrity": "sha512-HcTKfE5nE6y6ipjQf7mkE/yTsXALDa7EpsUHwPEVtadlC374PSg6ngXd1w03klSfiZAbWD5aBNbOAhbZ6algIg==",
+      "version": "17.3.2",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.3.2.tgz",
+      "integrity": "sha512-rmu2uGrVeoODjlp9WDTiaWUFszq6ehGXdkAqDeEd2p54FHHdklfVVti+D9D+OyacvT5OtrqjvLda47Zt6WjA1A==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@types/json-schema": "^7.0.9",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "glob": "^7.1.2",
@@ -10937,10 +10947,10 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.0.1",
+        "oas-normalize": "^5.0.5",
         "openapi-types": "^9.3.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^4.1.5"
+        "swagger-inline": "^5.0.2"
       },
       "bin": {
         "oas": "bin/oas"
@@ -10971,11 +10981,11 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.1.tgz",
-      "integrity": "sha512-GJStwIAjiJdHbzsqI5E492yL5duhG1Mrnbp0smRx5NEN/BkiFqPJDTG7JtI3VBKdHA023TUeCD3/XoKkg5a14g==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.5.tgz",
+      "integrity": "sha512-Ob+yK3Xh3fJn15rg7iu9ib+hHoHMwmIR0WBfhzX17eJU+LWEYMtaiYes3080ic4QE4O36FkIwuUMIyDCNv0OuQ==",
       "dependencies": {
-        "@readme/openapi-parser": "^1.1.0",
+        "@readme/openapi-parser": "^1.2.1",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -11228,9 +11238,9 @@
       }
     },
     "node_modules/openapi-types": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.0.tgz",
-      "integrity": "sha512-sR23YjmuwDSMsQVZDHbV9mPgi0RyniQlqR0AQxTC2/F3cpSjRFMH3CFPjoWvNqhC4OxPkDYNb2l8Mc1Me6D/KQ=="
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
+      "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw=="
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -12469,9 +12479,9 @@
       }
     },
     "node_modules/swagger-inline": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-4.2.2.tgz",
-      "integrity": "sha512-lu0PDx62Zp/rXQk7td0eAlincrpiVKfj/GPvel50+zVxfK1sI//kh/JSSm3EnVIibvjmFOojl+NTOcVOsrJPTA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.2.tgz",
+      "integrity": "sha512-Vdvuv9TzlnnRzue9ydXQBCe0otxh+rXz6vsLnUXwNqFjGWn/2OATYnyVEHojmKXS1fuMkaunVNsv0a9JT08UBw==",
       "dependencies": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",
@@ -14137,6 +14147,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "@humanwhocodes/momoa": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
+      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA=="
+    },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
@@ -15068,12 +15083,13 @@
       }
     },
     "@readme/better-ajv-errors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.1.1.tgz",
-      "integrity": "sha512-3FmPBv2fYj2Qgvg8Qq3wEL7CxLPA6nwkVGafdEfS/85DIUx9z0iZcHu48no/l0HOk9PCKUDqpinN6bTtLxD0og==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.3.0.tgz",
+      "integrity": "sha512-9yDff0hkbJJ/KaT+pVdHi6+2FeHsaImOz/LGqYp/auMBFSzUcP+y2kcte0pHrnePHgPp+Lt5H91RS5unwM++6Q==",
       "requires": {
         "@babel/code-frame": "^7.16.0",
         "@babel/runtime": "^7.16.0",
+        "@humanwhocodes/momoa": "^2.0.2",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -15151,6 +15167,32 @@
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       }
     },
+    "@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
+      }
+    },
     "@readme/oas-examples": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
@@ -15164,34 +15206,24 @@
       "requires": {}
     },
     "@readme/openapi-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.1.0.tgz",
-      "integrity": "sha512-gGoZk7yZ1MIFaFYgqm6HVaXgeIs4hCvVLys801llZF9CcXXE4DWBrpUk1VgU94cA08th6GWBLcMHiREr65Cw1A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
+      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^1.1.0",
+        "@readme/json-schema-ref-parser": "^1.0.0",
         "ajv": "^8.6.3",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": {
-          "version": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-          "from": "@apidevtools/json-schema-ref-parser@github:erunion/json-schema-ref-parser#fix/dates-as-strings",
-          "requires": {
-            "@jsdevtools/ono": "^7.1.3",
-            "@types/json-schema": "^7.0.6",
-            "call-me-maybe": "^1.0.1",
-            "js-yaml": "^4.1.0"
-          }
-        },
         "ajv": {
-          "version": "8.6.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -15204,19 +15236,6 @@
           "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
           "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
           "requires": {}
-        },
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
         },
         "json-schema-traverse": {
           "version": "1.0.0",
@@ -16629,13 +16648,6 @@
         "is-set": "^2.0.2",
         "is-string": "^1.0.5",
         "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        }
       }
     },
     "es-to-primitive": {
@@ -18358,6 +18370,11 @@
       "requires": {
         "call-bind": "^1.0.0"
       }
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -21446,11 +21463,12 @@
       "dev": true
     },
     "oas": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.1.6.tgz",
-      "integrity": "sha512-HcTKfE5nE6y6ipjQf7mkE/yTsXALDa7EpsUHwPEVtadlC374PSg6ngXd1w03klSfiZAbWD5aBNbOAhbZ6algIg==",
+      "version": "17.3.2",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.3.2.tgz",
+      "integrity": "sha512-rmu2uGrVeoODjlp9WDTiaWUFszq6ehGXdkAqDeEd2p54FHHdklfVVti+D9D+OyacvT5OtrqjvLda47Zt6WjA1A==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@types/json-schema": "^7.0.9",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "glob": "^7.1.2",
@@ -21460,10 +21478,10 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.0.1",
+        "oas-normalize": "^5.0.5",
         "openapi-types": "^9.3.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^4.1.5"
+        "swagger-inline": "^5.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -21530,11 +21548,11 @@
       }
     },
     "oas-normalize": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.1.tgz",
-      "integrity": "sha512-GJStwIAjiJdHbzsqI5E492yL5duhG1Mrnbp0smRx5NEN/BkiFqPJDTG7JtI3VBKdHA023TUeCD3/XoKkg5a14g==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.5.tgz",
+      "integrity": "sha512-Ob+yK3Xh3fJn15rg7iu9ib+hHoHMwmIR0WBfhzX17eJU+LWEYMtaiYes3080ic4QE4O36FkIwuUMIyDCNv0OuQ==",
       "requires": {
-        "@readme/openapi-parser": "^1.1.0",
+        "@readme/openapi-parser": "^1.2.1",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -21674,9 +21692,9 @@
       }
     },
     "openapi-types": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.0.tgz",
-      "integrity": "sha512-sR23YjmuwDSMsQVZDHbV9mPgi0RyniQlqR0AQxTC2/F3cpSjRFMH3CFPjoWvNqhC4OxPkDYNb2l8Mc1Me6D/KQ=="
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
+      "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw=="
     },
     "optionator": {
       "version": "0.9.1",
@@ -22632,9 +22650,9 @@
       }
     },
     "swagger-inline": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-4.2.2.tgz",
-      "integrity": "sha512-lu0PDx62Zp/rXQk7td0eAlincrpiVKfj/GPvel50+zVxfK1sI//kh/JSSm3EnVIibvjmFOojl+NTOcVOsrJPTA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.2.tgz",
+      "integrity": "sha512-Vdvuv9TzlnnRzue9ydXQBCe0otxh+rXz6vsLnUXwNqFjGWn/2OATYnyVEHojmKXS1fuMkaunVNsv0a9JT08UBw==",
       "requires": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@readme/oas-extensions": "^14.0.0",
-    "oas": "^17.1.0",
+    "oas": "^17.3.2",
     "parse-data-url": "^4.0.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -230,7 +230,7 @@ module.exports = (
     });
   }
 
-  // Are there `x-static` static headers configured for this OAS?
+  // Are there `x-headers` static headers configured for this OAS?
   const userDefinedHeaders = extensions.getExtension(extensions.HEADERS, oas, operation);
   if (userDefinedHeaders) {
     userDefinedHeaders.forEach(header => {
@@ -364,6 +364,7 @@ module.exports = (
                     }
                   });
 
+                  // `RAW_BODY` is a ReadMe-specific thing where we'll interpret its contents as raw JSON.
                   if (typeof cleanBody.RAW_BODY !== 'undefined') {
                     cleanBody = cleanBody.RAW_BODY;
                   }


### PR DESCRIPTION
## 🧰 What's being changed?

In the process of upgrading `oas` to the latest version here it ended up breaking a handful of tests because we removed handling for some `$ref` parsing in a few places, which led me to just full-bore overhauling the entire test suite because having a single `index.test.js` file that's 1.5k lines long is silly.

A lot of our tests were using some concoction of what `Oas.operation()` returns instead of just calling the damn method so I also updated all of our tests to test the entire `new Oas()` -> `oas.operation()` -> get HAR flow so these tests shouldn't be as fragile if we happen to update the return signature of `oas.operation()` in the future.

## 🧬 Testing

* [ ] Do you think these split up tests easier to read?