### PR TITLE
fix: issue where we'd try to stylize iterate over a nullilsh value

### DIFF
--- a/__tests__/lib/style-formatting/index.test.js
+++ b/__tests__/lib/style-formatting/index.test.js
@@ -54,6 +54,27 @@ test('should not crash on uri decoding errors', async () => {
   expect(har.log.entries[0].request.queryString).toStrictEqual([{ name: 'width', value: '20%25' }]);
 });
 
+test('should not crash for `explode: true` and `default: null` combinations', () => {
+  const oas = createOas('/query', {
+    parameters: [
+      {
+        in: 'query',
+        name: 'pet_id',
+        required: false,
+        explode: true,
+        schema: {
+          type: 'string',
+          default: null,
+        },
+      },
+    ],
+  });
+
+  expect(() => {
+    oasToHar(oas, oas.operation('/query', 'get'), { query: { pet_id: null } });
+  }).not.toThrow(TypeError);
+});
+
 /**
  * These tests ensure that each style matches the spec: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#style-values
  *    and the examples https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#style-examples.

--- a/src/lib/style-formatting/index.js
+++ b/src/lib/style-formatting/index.js
@@ -114,7 +114,7 @@ function handleExplode(value, parameter) {
     });
   }
 
-  if (typeof value === 'object') {
+  if (typeof value === 'object' && value !== null) {
     const newObj = {};
 
     Object.keys(value).forEach(key => {


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a bug where if a parameter has `explode: true` and `default: null`, and the form data being supplied was also `null` for that parameter, the library would crash because it was attempting to do iterate over a nullish value because `typeof null === 'object'`.

Fix in support of RM-3052.

## 🧬 Testing

See the test I added.