### PR TITLE
fix: check for orphaned apiDefinition-less endpoints

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -58,6 +58,14 @@ test('should accept an Operation instance as the operation schema', async () => 
   });
 });
 
+test('should return a valid HAR without an apiDefintion', async () => {
+  const spec = new Oas({});
+  const operation = spec.operation('/pet', 'post');
+  const har = oasToHar(spec, operation);
+
+  await expect(har).toBeAValidHAR();
+});
+
 describe('url', () => {
   it('should be constructed from oas.url()', () => {
     const spec = new Oas(petstore);

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,12 @@ module.exports = (
   operation.getParameters().forEach(addParameter);
 
   // Does this operation have any common parameters?
-  if (apiDefinition.paths && apiDefinition.paths[operation.path] && apiDefinition.paths[operation.path].parameters) {
+  if (
+    apiDefinition &&
+    apiDefinition.paths &&
+    apiDefinition.paths[operation.path] &&
+    apiDefinition.paths[operation.path].parameters
+  ) {
     apiDefinition.paths[operation.path].parameters.forEach(addParameter);
   }
 


### PR DESCRIPTION
## 🧰 What's being changed?

Endpoints in the manual api that had their definitions deleted prior to the fix made [here](https://github.com/readmeio/readme/pull/5419) were crashing due to `apiDefinition` being undefined

This checks for `apiDefinition` before trying to get `apiDefintion.paths`, which fixes the crashing and just displays what we can off the orphaned endpoint

## 🧬 Testing
See test
Can also make this change in `packages > react > node_modules > @readme > oas-to-har > index.js` to see it reflected locally from the readme repo
