### PR TITLE
feat: upgrading oas and replacing some deprecated accessors

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -34,6 +34,8 @@ test('should output a HAR object if no operation information is supplied', async
 
 test('should accept an Operation instance as the operation schema', async () => {
   const spec = new Oas(petstore);
+  await spec.dereference();
+
   const operation = spec.operation('/pet', 'post');
   const har = oasToHar(spec, operation);
 

--- a/__tests__/parameters.test.js
+++ b/__tests__/parameters.test.js
@@ -6,34 +6,6 @@ const commonParameters = require('./__fixtures__/common-parameters.json');
 
 expect.extend({ toBeAValidHAR });
 
-test('should work for schemas that require a parameters lookup', () => {
-  const spec = new Oas({
-    paths: {
-      '/': {
-        get: {
-          parameters: [
-            {
-              $ref: '#/components/parameters/authorization',
-            },
-          ],
-        },
-      },
-    },
-    components: {
-      parameters: {
-        authorization: {
-          name: 'Authorization',
-          in: 'header',
-        },
-      },
-    },
-  });
-
-  const har = oasToHar(spec, spec.operation('/', 'get'), { header: { Authorization: 'test' } });
-
-  expect(har.log.entries[0].request.headers[0].value).toBe('test');
-});
-
 describe('path', () => {
   it('should pass through unknown path params', () => {
     const spec = new Oas({
@@ -466,6 +438,8 @@ describe('header', () => {
 describe('common parameters', () => {
   it('should work for common parameters', async () => {
     const spec = new Oas(commonParameters);
+    await spec.dereference();
+
     const har = oasToHar(spec, spec.operation('/anything/{id}', 'post'), {
       path: { id: 1234 },
       header: { 'x-extra-id': 'abcd' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "14.1.0",
       "license": "ISC",
       "dependencies": {
-        "@readme/oas-extensions": "^14.1.0",
-        "oas": "^17.5.0",
+        "@readme/oas-extensions": "^14.1.1",
+        "oas": "^17.7.1",
         "parse-data-url": "^4.0.1"
       },
       "devDependencies": {
@@ -2104,9 +2104,9 @@
       "dev": true
     },
     "node_modules/@readme/oas-extensions": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.1.0.tgz",
-      "integrity": "sha512-Sso5Q95MFOxFDrj2OcoijUZMDHNwlk99TujXFJs5ghUGIN8V8oZZWWeRWgvHi76biOz3crNnD9dO73VUxU3pCA==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.1.1.tgz",
+      "integrity": "sha512-gvgfiFo4tAM6TRdRrQnBe+71WSLFK+k7gN1NXg9Io+waAQfw2KsKT9JlwwtZZf/WGE6NfoMp6d6l2eXVIguczQ==",
       "engines": {
         "node": "^12 || ^14 || ^16"
       },
@@ -2115,9 +2115,9 @@
       }
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.0.tgz",
-      "integrity": "sha512-QzDeBmARj2+PVnJswWQmiEkTjJljNKwP8EBCOjp0+3GmJp6BDEzy6VUEppGYdUJRaVfrLgqdYoiY1aFWlCBMVQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.2.tgz",
+      "integrity": "sha512-F7ge19kFvKvX0X4AOjtzkPHk6NaUWOds8K1xWndUVsnHAbGKVy9sbxCHV2mg90QbADySUEEot13YujOn3y3hZA==",
       "dependencies": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
@@ -2136,9 +2136,9 @@
       }
     },
     "node_modules/@readme/openapi-parser/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9129,9 +9129,9 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.5.0.tgz",
-      "integrity": "sha512-WWOPJgKtnjdIZmtTwWOpIAEy0aPfM3BGfLuwGj+DI9umzflLDsH4v7wrUqgugamaHKf0YN1vW29AucbRwJPLdQ==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.7.1.tgz",
+      "integrity": "sha512-LdCrKFQW6gzV7rKuTY7pxH2QxyE4l/uEC+yuk+e9vW+PxPCqR3fOf9+CF/4xZy65l0dvOfd180h5jDNHdrPkQQ==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "@types/json-schema": "^7.0.9",
@@ -9144,7 +9144,7 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.1.0",
+        "oas-normalize": "^5.1.1",
         "openapi-types": "^10.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^5.0.2"
@@ -9178,11 +9178,11 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.0.tgz",
-      "integrity": "sha512-lPVcc+yUzQZOKMKm6SXjmXI69Fgx3rPoPwRo1c/iaGdaVaoOSyB3NlweaW0qqdfuIx+gRz6ssTo9rpHvjsmQmA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.1.tgz",
+      "integrity": "sha512-CWVcWoEfICzFalw4IThB+l7u14TAhTLaloi2WPcowcc58Bw6+azehGX+6/WngDMyVt4jOBaQn/3gg0D1sy6YTg==",
       "dependencies": {
-        "@readme/openapi-parser": "^2.0.0",
+        "@readme/openapi-parser": "^2.0.2",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -12921,15 +12921,15 @@
       "dev": true
     },
     "@readme/oas-extensions": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.1.0.tgz",
-      "integrity": "sha512-Sso5Q95MFOxFDrj2OcoijUZMDHNwlk99TujXFJs5ghUGIN8V8oZZWWeRWgvHi76biOz3crNnD9dO73VUxU3pCA==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-extensions/-/oas-extensions-14.1.1.tgz",
+      "integrity": "sha512-gvgfiFo4tAM6TRdRrQnBe+71WSLFK+k7gN1NXg9Io+waAQfw2KsKT9JlwwtZZf/WGE6NfoMp6d6l2eXVIguczQ==",
       "requires": {}
     },
     "@readme/openapi-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.0.tgz",
-      "integrity": "sha512-QzDeBmARj2+PVnJswWQmiEkTjJljNKwP8EBCOjp0+3GmJp6BDEzy6VUEppGYdUJRaVfrLgqdYoiY1aFWlCBMVQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.2.tgz",
+      "integrity": "sha512-F7ge19kFvKvX0X4AOjtzkPHk6NaUWOds8K1xWndUVsnHAbGKVy9sbxCHV2mg90QbADySUEEot13YujOn3y3hZA==",
       "requires": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
@@ -12942,9 +12942,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -18115,9 +18115,9 @@
       "dev": true
     },
     "oas": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.5.0.tgz",
-      "integrity": "sha512-WWOPJgKtnjdIZmtTwWOpIAEy0aPfM3BGfLuwGj+DI9umzflLDsH4v7wrUqgugamaHKf0YN1vW29AucbRwJPLdQ==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.7.1.tgz",
+      "integrity": "sha512-LdCrKFQW6gzV7rKuTY7pxH2QxyE4l/uEC+yuk+e9vW+PxPCqR3fOf9+CF/4xZy65l0dvOfd180h5jDNHdrPkQQ==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
         "@types/json-schema": "^7.0.9",
@@ -18130,7 +18130,7 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.1.0",
+        "oas-normalize": "^5.1.1",
         "openapi-types": "^10.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^5.0.2"
@@ -18200,11 +18200,11 @@
       }
     },
     "oas-normalize": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.0.tgz",
-      "integrity": "sha512-lPVcc+yUzQZOKMKm6SXjmXI69Fgx3rPoPwRo1c/iaGdaVaoOSyB3NlweaW0qqdfuIx+gRz6ssTo9rpHvjsmQmA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.1.tgz",
+      "integrity": "sha512-CWVcWoEfICzFalw4IThB+l7u14TAhTLaloi2WPcowcc58Bw6+azehGX+6/WngDMyVt4jOBaQn/3gg0D1sy6YTg==",
       "requires": {
-        "@readme/openapi-parser": "^2.0.0",
+        "@readme/openapi-parser": "^2.0.2",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@readme/oas-extensions": "^14.1.0",
-    "oas": "^17.5.0",
+    "@readme/oas-extensions": "^14.1.1",
+    "oas": "^17.7.1",
     "parse-data-url": "^4.0.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const configureSecurity = require('./lib/configure-security');
 const removeUndefinedObjects = require('./lib/remove-undefined-objects');
 const formatStyle = require('./lib/style-formatting');
 
-const { getSchema, jsonSchemaTypes } = utils;
+const { jsonSchemaTypes } = utils;
 
 function formatter(values, param, type, onlyIfExists) {
   if (param.style) {
@@ -279,14 +279,12 @@ module.exports = (
     });
   }
 
-  let requestBody = getSchema(operation.schema, apiDefinition);
-  if (requestBody) {
-    requestBody = requestBody.schema;
-  } else {
-    requestBody = { schema: {} };
+  let requestBody = false;
+  if (operation.hasRequestBody()) {
+    [, requestBody] = operation.getRequestBody();
   }
 
-  if (requestBody.schema && Object.keys(requestBody.schema).length) {
+  if (requestBody && requestBody.schema && Object.keys(requestBody.schema).length) {
     if (operation.isFormUrlEncoded()) {
       if (Object.keys(formData.formData).length) {
         const cleanFormData = removeUndefinedObjects(JSON.parse(JSON.stringify(formData.formData)));
@@ -416,7 +414,7 @@ module.exports = (
 
   // Add a `Content-Type` header if there are any body values setup above or if there is a schema defined, but only do
   // so if we don't already have a `Content-Type` present as it's impossible for a request to have multiple.
-  if ((har.postData.text || Object.keys(requestBody.schema).length) && !hasContentType) {
+  if ((har.postData.text || (requestBody && Object.keys(requestBody.schema).length)) && !hasContentType) {
     har.headers.push({
       name: 'Content-Type',
       value: contentType,

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const configureSecurity = require('./lib/configure-security');
 const removeUndefinedObjects = require('./lib/remove-undefined-objects');
 const formatStyle = require('./lib/style-formatting');
 
-const { findSchemaDefinition, getSchema, jsonSchemaTypes } = utils;
+const { getSchema, jsonSchemaTypes } = utils;
 
 function formatter(values, param, type, onlyIfExists) {
   if (param.style) {
@@ -188,27 +188,7 @@ module.exports = (
     }
   }
 
-  // Does this operation have any parameters?
-  const parameters = [];
-  function addParameter(param) {
-    if (param.$ref) {
-      parameters.push(findSchemaDefinition(param.$ref, apiDefinition));
-    } else {
-      parameters.push(param);
-    }
-  }
-
-  operation.getParameters().forEach(addParameter);
-
-  // Does this operation have any common parameters?
-  if (
-    apiDefinition &&
-    apiDefinition.paths &&
-    apiDefinition.paths[operation.path] &&
-    apiDefinition.paths[operation.path].parameters
-  ) {
-    apiDefinition.paths[operation.path].parameters.forEach(addParameter);
-  }
+  const parameters = operation.getParameters();
 
   har.url = har.url.replace(/{([-_a-zA-Z0-9[\]]+)}/g, (full, key) => {
     if (!operation || !parameters) return key; // No path params at all


### PR DESCRIPTION
## 🧰 What's being changed?

This upgrades `oas` to the latest release and along with that:

* [x] Swaps out the now deprecated `getSchema` accessor with a combination of `hasRequestBody()` and `getRequestBody()`
* [x] Replaces some manual handling of common parameters with just a call to `getParameters()` that handles that automatically now.
  * Note that with this call we'll no longer support non-dereferenced specs with this library so I'll be publishing a breaking change release.

## 🧬 Testing

All tests should still be passing!