### PR TITLE
feat(styles): add space and pipe delimited support for objects per 3.1

### DIFF
--- a/__tests__/lib/style-formatting/index.test.js
+++ b/__tests__/lib/style-formatting/index.test.js
@@ -601,14 +601,12 @@ describe('query parameters', () => {
         { query: { color: arrayInput } },
         [],
       ],
-      // This is supposed to be supported, but the style-serializer library we use does not have support. Holding off for now.
-      /* [
+      [
         'should support space delimited query styles for non exploded object input',
         paramNoExplode,
         { query: { color: objectInput } },
-        // Note: this is space here, but %20 in the example above, because encoding happens far down the line
         [{ name: 'color', value: 'R 100 G 200 B 150' }],
-      ], */
+      ],
       [
         'should NOT support space delimited query styles for exploded object input',
         paramExplode,
@@ -690,13 +688,12 @@ describe('query parameters', () => {
         { query: { color: arrayInput } },
         [],
       ],
-      // This is supposed to be supported, but the style-seralizer library we use does not have support. Holding off for now.
-      /* [
+      [
         'should support pipe delimited query styles for non exploded object input',
         paramNoExplode,
         { query: { color: objectInput } },
         [{ name: 'color', value: 'R|100|G|200|B|150' }],
-      ], */
+      ],
       [
         'should NOT support pipe delimited query styles for exploded object input',
         paramExplode,

--- a/src/lib/style-formatting/style-serializer.js
+++ b/src/lib/style-formatting/style-serializer.js
@@ -188,6 +188,26 @@ function encodeObject({ location, key, value, style, explode, escape }) {
     }, '');
   }
 
+  // Supported in 3.1, added by Readme
+  if (style === 'spaceDelimited') {
+    return valueKeys.reduce((prev, curr) => {
+      const val = valueEncoder(value[curr]);
+      const prefix = prev ? `${prev} ` : '';
+
+      return `${prefix}${curr} ${val}`;
+    }, '');
+  }
+
+  // Supported in 3.1, added by Readme
+  if (style === 'pipeDelimited') {
+    return valueKeys.reduce((prev, curr) => {
+      const val = valueEncoder(value[curr]);
+      const prefix = prev ? `${prev}|` : '';
+
+      return `${prefix}${curr}|${val}`;
+    }, '');
+  }
+
   return undefined;
 }
 


### PR DESCRIPTION
## 🧰 What's being changed?

Add support for pipe delimited and space delimited objects, both of which are styles that were added for OAS 3.1

## 🧬 Testing

Check out the unit tests.
