### PR TITLE
fix: issue where null-assigned object properties would be filtered out

### DIFF
--- a/__tests__/requestBody.test.js
+++ b/__tests__/requestBody.test.js
@@ -69,6 +69,36 @@ describe('`body` data handling', () => {
     expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify({ a: 'test' }));
   });
 
+  it('should support a null-assigned property', () => {
+    const spec = new Oas({
+      paths: {
+        '/requestBody': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      foo: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { foo: null } });
+
+    expect(har.log.entries[0].request.postData.text).toBe(JSON.stringify({ foo: null }));
+  });
+
   it('should return nothing for undefined body property', () => {
     const spec = new Oas({
       paths: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@readme/oas-extensions": "^14.2.0",
         "oas": "^18.0.0",
         "parse-data-url": "^4.0.1",
-        "remove-undefined-objects": "^1.0.0"
+        "remove-undefined-objects": "^1.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
@@ -13267,9 +13267,9 @@
       }
     },
     "node_modules/remove-undefined-objects": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-1.0.0.tgz",
-      "integrity": "sha512-ZXVXz5kLJWPfV7C7XoNJccvw04Naq45FSFHC0ulvSLnggzYufTwMILBwrqO03V9lI7pt5RzLp3gwO19X/E9KFA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-1.1.0.tgz",
+      "integrity": "sha512-lZ8dJTI11nUE3M2l9lXHkXvhAxOquhLn/umJuBqu1Ea+4A10Wh0fymb36ioeze7UgCjYKIlZuSqjVZDtYa+FeQ==",
       "engines": {
         "node": "^12 || ^14 || ^16"
       }
@@ -25304,9 +25304,9 @@
       "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg=="
     },
     "remove-undefined-objects": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-1.0.0.tgz",
-      "integrity": "sha512-ZXVXz5kLJWPfV7C7XoNJccvw04Naq45FSFHC0ulvSLnggzYufTwMILBwrqO03V9lI7pt5RzLp3gwO19X/E9KFA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-1.1.0.tgz",
+      "integrity": "sha512-lZ8dJTI11nUE3M2l9lXHkXvhAxOquhLn/umJuBqu1Ea+4A10Wh0fymb36ioeze7UgCjYKIlZuSqjVZDtYa+FeQ=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@readme/oas-extensions": "^14.2.0",
     "oas": "^18.0.0",
     "parse-data-url": "^4.0.1",
-    "remove-undefined-objects": "^1.0.0"
+    "remove-undefined-objects": "^1.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",


### PR DESCRIPTION
## 🧰 Changes

This resolves an issue with our `remove-undefined-objects` dependency where it was mistakenly filtering out null-assigned object properties from our payloads.

See https://github.com/readmeio/remove-undefined-objects/pull/8 for details.
