### PR TITLE
fix: support for allowReserved

### DIFF
--- a/__tests__/lib/style-formatting/index.test.js
+++ b/__tests__/lib/style-formatting/index.test.js
@@ -416,6 +416,17 @@ describe('query parameters', () => {
       ],
     };
 
+    const paramReserved = {
+      parameters: [
+        {
+          name: 'color',
+          in: 'query',
+          style: 'form',
+          allowReserved: true,
+        },
+      ],
+    };
+
     const paramExplode = {
       parameters: [
         {
@@ -524,6 +535,15 @@ describe('query parameters', () => {
         [
           { name: 'pound', value: 'something%26nothing%3Dtrue' },
           { name: 'hash', value: 'hash%23data' },
+        ],
+      ],
+      [
+        'should support allowReserved for query parameters and not replace reserved characters',
+        paramReserved,
+        { query: { color: objectInputEncoded } },
+        [
+          { name: 'pound', value: 'something&nothing=true' },
+          { name: 'hash', value: 'hash#data' },
         ],
       ],
     ])('%s', async (_, operation = {}, formData = {}, expectedQueryString = []) => {

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,8 @@ const formatStyle = require('./lib/style-formatting');
 
 const { jsonSchemaTypes } = utils;
 
-function formatter(values, param, type, onlyIfExists, serialize) {
-  if (param.style && serialize) {
+function formatter(values, param, type, onlyIfExists) {
+  if (param.style) {
     const value = values[type][param.name];
     // Note: Technically we could send everything through the format style and choose the proper default for each
     //  `in` type (e.g. query defaults to form).
@@ -38,7 +38,7 @@ function formatter(values, param, type, onlyIfExists, serialize) {
 
   if (value !== undefined) {
     // Query params should always be formatted, even if they don't have a `style` serialization configured.
-    if (type === 'query' && serialize) {
+    if (type === 'query') {
       return formatStyle(value, param);
     }
 
@@ -146,8 +146,6 @@ module.exports = (
     // If true, the operation URL will be rewritten and prefixed with https://try.readme.io/ in order to funnel requests
     // through our CORS-friendly proxy.
     proxyUrl: false,
-    // If false, completely disable style serialization and bypass calling formatStyle()
-    serialize: true,
   }
 ) => {
   let operation = operationSchema;
@@ -200,16 +198,16 @@ module.exports = (
 
     // The library that handles our style processing already encodes uri elements. For everything else we need to handle it here.
     if (!parameter.style) {
-      return encodeURIComponent(formatter(formData, parameter, 'path', false, opts.serialize));
+      return encodeURIComponent(formatter(formData, parameter, 'path'));
     }
 
-    return formatter(formData, parameter, 'path', false, opts.serialize);
+    return formatter(formData, parameter, 'path');
   });
 
   const queryStrings = parameters && parameters.filter(param => param.in === 'query');
   if (queryStrings && queryStrings.length) {
     queryStrings.forEach(queryString => {
-      const value = formatter(formData, queryString, 'query', true, opts.serialize);
+      const value = formatter(formData, queryString, 'query', true);
       appendHarValue(har.queryString, queryString.name, value);
     });
   }
@@ -218,7 +216,7 @@ module.exports = (
   const cookies = parameters && parameters.filter(param => param.in === 'cookie');
   if (cookies && cookies.length) {
     cookies.forEach(cookie => {
-      const value = formatter(formData, cookie, 'cookie', true, opts.serialize);
+      const value = formatter(formData, cookie, 'cookie', true);
       appendHarValue(har.cookies, cookie.name, value);
     });
   }
@@ -246,7 +244,7 @@ module.exports = (
   const headers = parameters && parameters.filter(param => param.in === 'header');
   if (headers && headers.length) {
     headers.forEach(header => {
-      const value = formatter(formData, header, 'header', true, opts.serialize);
+      const value = formatter(formData, header, 'header', true);
       if (typeof value === 'undefined') return;
 
       if (header.name.toLowerCase() === 'content-type') {
@@ -333,7 +331,7 @@ module.exports = (
               Object.keys(cleanBody).forEach(name => {
                 const param = multipartParams.find(multipartParam => multipartParam.name === name);
 
-                const value = formatter(formData, param, 'body', true, opts.serialize);
+                const value = formatter(formData, param, 'body', true);
 
                 // If we're dealing with a binary type, and the value is a valid data URL we should parse out any
                 // available filename and content type to send along with the parameter to interpreters like `fetch-har`

--- a/src/lib/style-formatting/index.js
+++ b/src/lib/style-formatting/index.js
@@ -103,6 +103,7 @@ function stylizeValue(value, parameter) {
       I do not know if it is correct for query to use this. See style-serializer for more info
     */
     escape: true,
+    ...(parameter.in === 'query' ? { isAllowedReserved: parameter.allowReserved || false } : {}),
   });
 }
 

--- a/src/lib/style-formatting/style-serializer.js
+++ b/src/lib/style-formatting/style-serializer.js
@@ -86,7 +86,7 @@ module.exports.encodeDisallowedCharacters = function encodeDisallowedCharacters(
     .join('');
 };
 
-function encodeArray({ location, key, value, style, explode, escape, isAllowedReserved }) {
+function encodeArray({ location, key, value, style, explode, escape, isAllowedReserved = false }) {
   const valueEncoder = str =>
     module.exports.encodeDisallowedCharacters(str, {
       escape,
@@ -131,7 +131,7 @@ function encodeArray({ location, key, value, style, explode, escape, isAllowedRe
   return undefined;
 }
 
-function encodeObject({ location, key, value, style, explode, escape, isAllowedReserved }) {
+function encodeObject({ location, key, value, style, explode, escape, isAllowedReserved = false }) {
   const valueEncoder = str =>
     module.exports.encodeDisallowedCharacters(str, {
       escape,

--- a/src/lib/style-formatting/style-serializer.js
+++ b/src/lib/style-formatting/style-serializer.js
@@ -36,7 +36,7 @@ module.exports = function stylize(config) {
 
 module.exports.encodeDisallowedCharacters = function encodeDisallowedCharacters(
   str,
-  { escape, returnIfEncoded = false } = {}, // eslint-disable-line default-param-last
+  { escape, returnIfEncoded = false, isAllowedReserved } = {}, // eslint-disable-line default-param-last
   parse
 ) {
   if (typeof str === 'number') {
@@ -71,7 +71,7 @@ module.exports.encodeDisallowedCharacters = function encodeDisallowedCharacters(
         return char;
       }
 
-      if (isRfc3986Reserved(char) && escape === 'unsafe') {
+      if (isRfc3986Reserved(char) && (escape === 'unsafe' || isAllowedReserved)) {
         return char;
       }
 
@@ -86,11 +86,12 @@ module.exports.encodeDisallowedCharacters = function encodeDisallowedCharacters(
     .join('');
 };
 
-function encodeArray({ location, key, value, style, explode, escape }) {
+function encodeArray({ location, key, value, style, explode, escape, isAllowedReserved }) {
   const valueEncoder = str =>
     module.exports.encodeDisallowedCharacters(str, {
       escape,
       returnIfEncoded: location === 'query',
+      isAllowedReserved,
     });
 
   if (style === 'simple') {
@@ -130,11 +131,12 @@ function encodeArray({ location, key, value, style, explode, escape }) {
   return undefined;
 }
 
-function encodeObject({ location, key, value, style, explode, escape }) {
+function encodeObject({ location, key, value, style, explode, escape, isAllowedReserved }) {
   const valueEncoder = str =>
     module.exports.encodeDisallowedCharacters(str, {
       escape,
       returnIfEncoded: location === 'query',
+      isAllowedReserved,
     });
 
   const valueKeys = Object.keys(value);
@@ -211,11 +213,12 @@ function encodeObject({ location, key, value, style, explode, escape }) {
   return undefined;
 }
 
-function encodePrimitive({ location, key, value, style, escape }) {
+function encodePrimitive({ location, key, value, style, escape, isAllowedReserved = false }) {
   const valueEncoder = str =>
     module.exports.encodeDisallowedCharacters(str, {
       escape,
       returnIfEncoded: location === 'query' || location === 'body',
+      isAllowedReserved,
     });
 
   if (style === 'simple') {


### PR DESCRIPTION
| 🚥 Fix RM-4129 |
| :-- |

## 🧰 Changes

- No longer removes reserved characters if `allowReserved` is true on query params

## 🧬 QA & Testing
- Check the tests under 'query' in `/__tests__/lib/style-formatting/index.test.js`
