### PR TITLE
fix: support for multi-level deepObjects

### DIFF
--- a/__tests__/__fixtures__/create-oas.js
+++ b/__tests__/__fixtures__/create-oas.js
@@ -1,0 +1,13 @@
+const Oas = require('oas').default;
+
+module.exports = function createOas(method) {
+  return function (path, operation) {
+    return new Oas({
+      paths: {
+        [path]: {
+          [method]: operation,
+        },
+      },
+    });
+  };
+};

--- a/__tests__/__fixtures__/style-data.js
+++ b/__tests__/__fixtures__/style-data.js
@@ -1,0 +1,13 @@
+module.exports = {
+  emptyInput: '',
+  undefinedInput: undefined,
+  stringInput: 'blue',
+  stringInputEncoded: encodeURIComponent('something&nothing=true'),
+  arrayInput: ['blue', 'black', 'brown'],
+  arrayInputEncoded: ['something&nothing=true', 'hash#data'],
+  undefinedArrayInput: [undefined],
+  objectInput: { R: 100, G: 200, B: 150 },
+  objectNestedObject: { id: 'someID', child: { name: 'childName', age: null, metadata: { name: 'meta' } } },
+  objectInputEncoded: { pound: 'something&nothing=true', hash: 'hash#data' },
+  undefinedObjectInput: { R: undefined },
+};

--- a/__tests__/__fixtures__/style-data.js
+++ b/__tests__/__fixtures__/style-data.js
@@ -1,13 +1,34 @@
 module.exports = {
-  emptyInput: '',
-  undefinedInput: undefined,
-  stringInput: 'blue',
-  stringInputEncoded: encodeURIComponent('something&nothing=true'),
   arrayInput: ['blue', 'black', 'brown'],
   arrayInputEncoded: ['something&nothing=true', 'hash#data'],
-  undefinedArrayInput: [undefined],
+
+  emptyInput: '',
+
   objectInput: { R: 100, G: 200, B: 150 },
-  objectNestedObject: { id: 'someID', child: { name: 'childName', age: null, metadata: { name: 'meta' } } },
   objectInputEncoded: { pound: 'something&nothing=true', hash: 'hash#data' },
+
+  objectNestedObject: {
+    id: 'someID',
+    child: { name: 'childName', age: null, metadata: { name: 'meta' } },
+  },
+
+  objectNestedObjectOfARidiculiousShape: {
+    id: 'someID',
+    petLicense: null,
+    dog: { name: 'buster', age: 18, treats: ['peanut butter', 'apple'] },
+    pets: [
+      {
+        name: 'buster',
+        age: null,
+        metadata: { isOld: true },
+      },
+    ],
+  },
+
+  stringInput: 'blue',
+  stringInputEncoded: encodeURIComponent('something&nothing=true'),
+
+  undefinedArrayInput: [undefined],
+  undefinedInput: undefined,
   undefinedObjectInput: { R: undefined },
 };

--- a/__tests__/lib/style-formatting/index.test.js
+++ b/__tests__/lib/style-formatting/index.test.js
@@ -1,33 +1,26 @@
-const Oas = require('oas').default;
 const oasToHar = require('../../../src');
 const toBeAValidHAR = require('jest-expect-har').default;
 
-expect.extend({ toBeAValidHAR });
+const createOas = require('../../__fixtures__/create-oas')('get');
+const {
+  emptyInput,
+  undefinedInput,
+  stringInput,
+  stringInputEncoded,
+  arrayInput,
+  arrayInputEncoded,
+  undefinedArrayInput,
+  objectInput,
+  objectNestedObject,
+  objectInputEncoded,
+  undefinedObjectInput,
+} = require('../../__fixtures__/style-data');
 
-const emptyInput = '';
-const undefinedInput = undefined;
-const stringInput = 'blue';
-const stringInputEncoded = encodeURIComponent('something&nothing=true');
-const arrayInput = ['blue', 'black', 'brown'];
-const arrayInputEncoded = ['something&nothing=true', 'hash#data'];
-const undefinedArrayInput = [undefined];
-const objectInput = { R: 100, G: 200, B: 150 };
-const objectInputEncoded = { pound: 'something&nothing=true', hash: 'hash#data' };
-const undefinedObjectInput = { R: undefined };
+expect.extend({ toBeAValidHAR });
 
 const semicolon = ';'; // %3B when encoded, which we don't want
 const equals = '='; // %3D when encoded, which we don't want
 const comma = ','; // %2C when encoded, which we don't want
-
-function createOas(path, operation) {
-  return new Oas({
-    paths: {
-      [path]: {
-        get: operation,
-      },
-    },
-  });
-}
 
 test('should not crash on uri decoding errors', async () => {
   const oas = createOas('/query', {
@@ -803,6 +796,23 @@ describe('query parameters', () => {
           { name: 'color[R]', value: '100' },
           { name: 'color[G]', value: '200' },
           { name: 'color[B]', value: '150' },
+        ],
+      ],
+      [
+        'should NOT support deepObject delimited query styles for non exploded nested object input',
+        paramNoExplode,
+        { query: { color: objectNestedObject } },
+        [],
+      ],
+      [
+        'should support deepObject delimited query styles for exploded nested object input',
+        paramExplode,
+        { query: { color: objectNestedObject } },
+        [
+          { name: 'color[id]', value: 'someID' },
+          { name: 'color[child][name]', value: 'childName' },
+          { name: 'color[child][age]', value: 'null' },
+          { name: 'color[child][metadata][name]', value: 'meta' },
         ],
       ],
       [

--- a/__tests__/lib/style-formatting/index.test.js
+++ b/__tests__/lib/style-formatting/index.test.js
@@ -12,6 +12,7 @@ const {
   undefinedArrayInput,
   objectInput,
   objectNestedObject,
+  objectNestedObjectOfARidiculiousShape,
   objectInputEncoded,
   undefinedObjectInput,
 } = require('../../__fixtures__/style-data');
@@ -813,6 +814,22 @@ describe('query parameters', () => {
           { name: 'color[child][name]', value: 'childName' },
           { name: 'color[child][age]', value: 'null' },
           { name: 'color[child][metadata][name]', value: 'meta' },
+        ],
+      ],
+      [
+        'should support deepObject delimited query styles for exploded nested object (of a ridiculious shape) input',
+        paramExplode,
+        { query: { color: objectNestedObjectOfARidiculiousShape } },
+        [
+          { name: 'color[id]', value: 'someID' },
+          { name: 'color[petLicense]', value: 'null' },
+          { name: 'color[dog][name]', value: 'buster' },
+          { name: 'color[dog][age]', value: '18' },
+          { name: 'color[dog][treats][0]', value: 'peanut%20butter' },
+          { name: 'color[dog][treats][1]', value: 'apple' },
+          { name: 'color[pets][0][name]', value: 'buster' },
+          { name: 'color[pets][0][age]', value: 'null' },
+          { name: 'color[pets][0][metadata][isOld]', value: 'true' },
         ],
       ],
       [

--- a/__tests__/lib/style-formatting/multipart-form-data.test.js
+++ b/__tests__/lib/style-formatting/multipart-form-data.test.js
@@ -10,6 +10,7 @@ const {
   arrayInputEncoded,
   objectInput,
   objectNestedObject,
+  objectNestedObjectOfARidiculiousShape,
   objectInputEncoded,
 } = require('../../__fixtures__/style-data');
 
@@ -402,6 +403,22 @@ describe('multipart/form-data parameters', () => {
           { name: 'object[child][name]', value: 'childName' },
           { name: 'object[child][age]', value: 'null' },
           { name: 'object[child][metadata][name]', value: 'meta' },
+        ],
+      ],
+      [
+        'should support deepObject styles for nested objects past 1 level depth (and with a ridiculious shape)',
+        bodyExplode,
+        { body: { object: objectNestedObjectOfARidiculiousShape } },
+        [
+          { name: 'object[id]', value: 'someID' },
+          { name: 'object[petLicense]', value: 'null' },
+          { name: 'object[dog][name]', value: 'buster' },
+          { name: 'object[dog][age]', value: '18' },
+          { name: 'object[dog][treats][0]', value: 'peanut%20butter' },
+          { name: 'object[dog][treats][1]', value: 'apple' },
+          { name: 'object[pets][0][name]', value: 'buster' },
+          { name: 'object[pets][0][age]', value: 'null' },
+          { name: 'object[pets][0][metadata][isOld]', value: 'true' },
         ],
       ],
     ])('%s', async (_, operation = {}, formData = {}, expectedRequestBody = undefined) => {

--- a/__tests__/lib/style-formatting/multipart-form-data.test.js
+++ b/__tests__/lib/style-formatting/multipart-form-data.test.js
@@ -10,6 +10,7 @@ const stringInputEncoded = encodeURIComponent('something&nothing=true');
 const arrayInput = ['blue', 'black', 'brown'];
 const arrayInputEncoded = ['something&nothing=true', 'hash#data'];
 const objectInput = { R: 100, G: 200, B: 150 };
+const objectNestedObject = { id: 'someID', child: { name: 'childName', metadata: { name: 'meta' } } };
 const objectInputEncoded = { pound: 'something&nothing=true', hash: 'hash#data' };
 
 function createOas(path, operation) {
@@ -400,11 +401,20 @@ describe('multipart/form-data parameters', () => {
           { name: 'object[hash]', value: 'hash%23data' },
         ],
       ],
+      [
+        'should support deepObject styles for nested objects past 1 level depth',
+        bodyExplode,
+        { body: { object: objectNestedObject } },
+        [
+          { name: 'object[id]', value: 'someID' },
+          { name: 'object[child][name]', value: 'childName' },
+          { name: 'object[child][metadata][name]', value: 'meta' },
+        ],
+      ],
     ])('%s', async (_, operation = {}, formData = {}, expectedRequestBody = undefined) => {
       const oas = createOas('/body', operation);
       const har = oasToHar(oas, oas.operation('/body', 'post'), formData);
       await expect(har).toBeAValidHAR();
-
       expect(har.log.entries[0].request.postData.params).toStrictEqual(expectedRequestBody);
     });
   });

--- a/__tests__/lib/style-formatting/multipart-form-data.test.js
+++ b/__tests__/lib/style-formatting/multipart-form-data.test.js
@@ -1,27 +1,19 @@
-const Oas = require('oas').default;
 const oasToHar = require('../../../src');
 const toBeAValidHAR = require('jest-expect-har').default;
 
+const createOas = require('../../__fixtures__/create-oas')('post');
+const {
+  emptyInput,
+  stringInput,
+  stringInputEncoded,
+  arrayInput,
+  arrayInputEncoded,
+  objectInput,
+  objectNestedObject,
+  objectInputEncoded,
+} = require('../../__fixtures__/style-data');
+
 expect.extend({ toBeAValidHAR });
-
-const emptyInput = '';
-const stringInput = 'blue';
-const stringInputEncoded = encodeURIComponent('something&nothing=true');
-const arrayInput = ['blue', 'black', 'brown'];
-const arrayInputEncoded = ['something&nothing=true', 'hash#data'];
-const objectInput = { R: 100, G: 200, B: 150 };
-const objectNestedObject = { id: 'someID', child: { name: 'childName', metadata: { name: 'meta' } } };
-const objectInputEncoded = { pound: 'something&nothing=true', hash: 'hash#data' };
-
-function createOas(path, operation) {
-  return new Oas({
-    paths: {
-      [path]: {
-        post: operation,
-      },
-    },
-  });
-}
 
 function buildBody(style, explode) {
   return {
@@ -408,6 +400,7 @@ describe('multipart/form-data parameters', () => {
         [
           { name: 'object[id]', value: 'someID' },
           { name: 'object[child][name]', value: 'childName' },
+          { name: 'object[child][age]', value: 'null' },
           { name: 'object[child][metadata][name]', value: 'meta' },
         ],
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@readme/oas-extensions": "^14.2.0",
         "oas": "^18.0.6",
         "parse-data-url": "^4.0.1",
+        "qs": "^6.10.3",
         "remove-undefined-objects": "^1.1.0"
       },
       "devDependencies": {
@@ -12809,6 +12810,20 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -24940,6 +24955,14 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
+    },
+    "qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "queue": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "prettier": "^2.6.0"
   },
   "prettier": "@readme/eslint-config/prettier",
+  "jest": {
+    "testPathIgnorePatterns": ["/__tests__/__fixtures__/", "/__tests__/(.*)/__fixtures__/"]
+  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@readme/oas-extensions": "^14.2.0",
     "oas": "^18.0.6",
     "parse-data-url": "^4.0.1",
+    "qs": "^6.10.3",
     "remove-undefined-objects": "^1.1.0"
   },
   "devDependencies": {
@@ -42,7 +43,10 @@
   },
   "prettier": "@readme/eslint-config/prettier",
   "jest": {
-    "testPathIgnorePatterns": ["/__tests__/__fixtures__/", "/__tests__/(.*)/__fixtures__/"]
+    "testPathIgnorePatterns": [
+      "/__tests__/__fixtures__/",
+      "/__tests__/(.*)/__fixtures__/"
+    ]
   },
   "commitlint": {
     "extends": [

--- a/src/lib/style-formatting/index.js
+++ b/src/lib/style-formatting/index.js
@@ -152,14 +152,13 @@ function handleExplode(value, parameter) {
     const newObj = {};
 
     Object.keys(value).forEach(key => {
-      const stylizedValue = stylizeValue(value[key], parameter);
       if (parameter.style === 'deepObject') {
         const deepObjs = handleDeepObject(value, parameter);
         deepObjs.forEach(obj => {
           newObj[obj.label] = obj.value;
         });
       } else {
-        newObj[key] = stylizedValue;
+        newObj[key] = stylizeValue(value[key], parameter);
       }
     });
 

--- a/src/lib/style-formatting/index.js
+++ b/src/lib/style-formatting/index.js
@@ -116,7 +116,7 @@ function handleDeepObject(value, parameter) {
         if (type === 'key') {
           // `str` will be here as `dog[treats][0]` but because the `qs` library doesn't have any
           // awareness of our OpenAPI parameters we need to rewrite it to slap the `parameter.name`
-          // to the top, like `${parameter.name}[dog][treats][0]`.
+          // to the top, like `pets[dog][treats][0]`.
           const prefixedKey = str
             .split(/[[\]]/g)
             .filter(Boolean)

--- a/src/lib/style-formatting/index.js
+++ b/src/lib/style-formatting/index.js
@@ -109,29 +109,27 @@ function stylizeValue(value, parameter) {
 
 function handleNestedObject(value, key, childKey, stylizedValue, parameter, template) {
   const label = `${template}[${childKey}]`;
-  let obj = {};
 
-  if (typeof value[key][childKey] === 'object') {
+  if (typeof value[key][childKey] === 'object' && value[key][childKey] !== null) {
+    let obj = {};
     Object.keys(value[key][childKey]).forEach(grandchildKey => {
       obj = handleNestedObject(value[key], childKey, grandchildKey, stylizedValue, parameter, label);
     });
-  } else {
-    /* eslint-disable-next-line no-param-reassign */
-    stylizedValue = stylizeValue(value[key][childKey], parameter);
-    obj = {
-      label,
-      value: stylizedValue,
-    };
+
+    return obj;
   }
 
-  return obj;
+  return {
+    label,
+    value: stylizeValue(value[key][childKey], parameter),
+  };
 }
 
 function handleDeepObject(value, key, stylizedValue, parameter) {
   const template = `${parameter.name}[${key}]`;
   const deepObjs = [];
 
-  if (typeof value[key] === 'object') {
+  if (typeof value[key] === 'object' && value[key] !== null) {
     const keys = Object.keys(value[key]);
 
     keys.forEach(childKey => {

--- a/src/lib/style-formatting/style-serializer.js
+++ b/src/lib/style-formatting/style-serializer.js
@@ -210,6 +210,13 @@ function encodeObject({ location, key, value, style, explode, escape, isAllowedR
     }, '');
   }
 
+  if (style === 'deepObject') {
+    return valueKeys.reduce(curr => {
+      const val = valueEncoder(value[curr], {}, true);
+      return `${val}`;
+    }, '');
+  }
+
   return undefined;
 }
 


### PR DESCRIPTION
| 🚥 Fix RM-4178 |
| :-- |

## 🧰 Changes

This rewrites our support for `deepObject` handling to better support multi-level objects. 

## 🧬 QA & Testing

All tests still pass, the test I wrote still passes, & you can put this locally in `packages > react > node_modules > @readme > oas-to-har` to play around with on the local playground. Customer spec is in the linked ticket.

This is this work in action in the explorer playground:

![Screen Shot 2022-04-21 at 5 01 29 PM](https://user-images.githubusercontent.com/33762/164569817-c320a0f5-e536-4b77-ac92-cd5c3cf11037.png)

And a `node-fetch` snippet generated with `@readme/oas-to-snippet` using this code:

```js
const fetch = require('node-fetch');

const url = 'https://httpbin.org/anything/events?limit=5345&offset=545&where[columns][name]=colujnnewfwe&where[columns][type]=update&where[id]=gg&where[transaction_id]=erfewrf';
const options = {method: 'POST'};

fetch(url, options)
  .then(res => res.json())
  .then(json => console.log(json))
  .catch(err => console.error('error:' + err));
```
