### PR TITLE
fix: issue where a lowercase `Accept` header may be duplicated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -232,8 +232,9 @@ module.exports = (
     Object.keys(operation.schema.responses).some(response => {
       if (!operation.schema.responses[response].content) return false;
 
-      // if there is an Accept header specified in the form, we'll use that instead.
-      if (formData.header.Accept) return true;
+      // If there's no `Accept` header present we should add one so their eventual code snippet
+      // follows best practices.
+      if (Object.keys(formData.header).find(h => h.toLowerCase() === 'accept')) return true;
 
       har.headers.push({
         name: 'Accept',
@@ -278,10 +279,16 @@ module.exports = (
   }
 
   // Do we have an `Accept` header set up in the form, but it hasn't been added yet?
-  if (formData.header && formData.header.Accept && har.headers.find(hdr => hdr.name === 'Accept') === undefined) {
+  if (
+    formData.header &&
+    Object.keys(formData.header).find(h => h.toLowerCase() === 'accept') &&
+    !har.headers.find(hdr => hdr.name.toLowerCase() === 'accept')
+  ) {
+    const acceptHeader = Object.keys(formData.header).find(h => h.toLowerCase() === 'accept');
+
     har.headers.push({
       name: 'Accept',
-      value: String(formData.header.Accept),
+      value: String(formData.header[acceptHeader]),
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -279,17 +279,14 @@ module.exports = (
   }
 
   // Do we have an `Accept` header set up in the form, but it hasn't been added yet?
-  if (
-    formData.header &&
-    Object.keys(formData.header).find(h => h.toLowerCase() === 'accept') &&
-    !har.headers.find(hdr => hdr.name.toLowerCase() === 'accept')
-  ) {
+  if (formData.header) {
     const acceptHeader = Object.keys(formData.header).find(h => h.toLowerCase() === 'accept');
-
-    har.headers.push({
-      name: 'Accept',
-      value: String(formData.header[acceptHeader]),
-    });
+    if (acceptHeader && !har.headers.find(hdr => hdr.name.toLowerCase() === 'accept')) {
+      har.headers.push({
+        name: 'Accept',
+        value: String(formData.header[acceptHeader]),
+      });
+    }
   }
 
   let requestBody = false;

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -362,7 +362,7 @@ describe('parameter handling', function () {
         [{ name: 'a', value: 'test' }],
       ],
       [
-        'should pass accept header if endpoint expects a content back from response',
+        'should pass `Accept`  header if endpoint expects a content back from response',
         {
           parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
           responses: {
@@ -381,7 +381,7 @@ describe('parameter handling', function () {
         ],
       ],
       [
-        'should only add one accept header',
+        'should only add one `Accept` header when multiple responses are present',
         {
           responses: {
             200: {
@@ -400,9 +400,9 @@ describe('parameter handling', function () {
         [{ name: 'Accept', value: 'application/xml' }],
       ],
       [
-        'should only receive one accept header if specified in values',
+        'should only receive one `Accept` header if specified in values',
         {
-          parameters: [{ name: 'Accept', in: 'header' }],
+          parameters: [{ name: 'accept', in: 'header' }],
           responses: {
             200: {
               content: {
@@ -412,11 +412,11 @@ describe('parameter handling', function () {
             },
           },
         },
-        { header: { Accept: 'application/xml' } },
-        [{ name: 'Accept', value: 'application/xml' }],
+        { header: { accept: 'application/xml' } },
+        [{ name: 'accept', value: 'application/xml' }],
       ],
       [
-        'should add accept header if specified in formdata',
+        'should add `Accept` header if specified in formdata',
         {
           responses: {
             200: {
@@ -427,7 +427,7 @@ describe('parameter handling', function () {
             },
           },
         },
-        { header: { Accept: 'application/xml' } },
+        { header: { accept: 'application/xml' } },
         [{ name: 'Accept', value: 'application/xml' }],
       ],
       [


### PR DESCRIPTION
| 🚥 Fix RM-4281 |
| :-- |

## 🧰 Changes

This resolves a bug where if we were being supplied `header` formdata with an `accept` header, we'd end up adding an `accept` and `Accept` header into the HAR.

## 🧬 QA & Testing

I lowercased some of the cases that deal with adding this header if it's coming from form data to ensure that we handle case-insensitivity properly.