### PR TITLE
feat: adding support for RAW_BODY payloads when not on JSON-like content types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -396,8 +396,8 @@ module.exports = (
                     }
                   });
 
-                  // `RAW_BODY` is a ReadMe-specific thing where we'll interpret its contents as
-                  // raw JSON.
+                  // `RAW_BODY` is a ReadMe-specific thing where we'll interpret the entire payload
+                  // as a raw string. https://docs.readme.com/docs/raw-body-content
                   if (typeof cleanBody.RAW_BODY !== 'undefined') {
                     cleanBody = cleanBody.RAW_BODY;
                   }
@@ -420,6 +420,15 @@ module.exports = (
         har.postData.mimeType = contentType;
         if (isPrimitive(formData.body)) {
           har.postData.text = formData.body;
+        } else if (
+          typeof formData.body === 'object' &&
+          formData.body !== null &&
+          !Array.isArray(formData.body) &&
+          typeof formData.body.RAW_BODY !== 'undefined'
+        ) {
+          // `RAW_BODY` is a ReadMe-specific thing where we'll interpret the entire payload as a
+          // raw string. https://docs.readme.com/docs/raw-body-content
+          har.postData.text = formData.body.RAW_BODY;
         } else {
           har.postData.text = stringify(formData.body);
         }

--- a/test/__datasets__/requestBody-raw_body.json
+++ b/test/__datasets__/requestBody-raw_body.json
@@ -50,6 +50,26 @@
         }
       }
     },
+    "/xml": {
+      "post": {
+        "summary": "`RAW_BODY` handling of string content with `format: xml`.",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "RAW_BODY": {
+                    "type": "string",
+                    "format": "xml"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/objects": {
       "post": {
         "summary": "`RAW_BODY` handling of shaped objects.",

--- a/test/requestBody.test.js
+++ b/test/requestBody.test.js
@@ -363,6 +363,13 @@ describe('request body handling', function () {
         expect(har.log.entries[0].request.postData.text).to.equal(JSON.stringify({ a: 1 }));
       });
 
+      it('should work for RAW_BODY xml', function () {
+        const spec = new Oas(requestBodyRawBody);
+        const har = oasToHar(spec, spec.operation('/xml', 'post'), { body: { RAW_BODY: '<xml>' } });
+
+        expect(har.log.entries[0].request.postData.text).to.equal('<xml>');
+      });
+
       it('should work for RAW_BODY objects', function () {
         const spec = new Oas(requestBodyRawBody);
         const har = oasToHar(spec, spec.operation('/objects', 'post'), { body: { RAW_BODY: { a: 'test' } } });


### PR DESCRIPTION
| 🚥 Fix RM-3107 |
| :-- |

## 🧰 Changes

This updates our [custom `RAW_BODY` handling](https://docs.readme.com/docs/raw-body-content) for delivering raw payloads to support it when in use on non-JSON content types like `application/xml`.

Without this fix, `RAW_BODY` content for these situations would be double-stringified into the HAR, resulting in some targets in [@readme/oas-to-snippet](https://npm.im/@readme/oas-to-snippet) improperly rendering it the snippet:
 
![Screen Shot 2022-04-24 at 5 14 46 PM](https://user-images.githubusercontent.com/33762/165002717-874aa862-3098-4aa3-bf0b-1e9bb7763322.png)

## 🧬 QA & Testing

See the test I added for supporting it on an `application/xml` request body.

With this fix, these payloads won't be rendered within another set of quotes:

![Screen Shot 2022-04-24 at 5 14 26 PM](https://user-images.githubusercontent.com/33762/165002733-5c23dd1d-0ec1-4093-bb30-5f04e938dbab.png)