### PR TITLE
fix: more quirks with handling RAW_BODY primitives

### DIFF
--- a/test/requestBody.test.js
+++ b/test/requestBody.test.js
@@ -385,14 +385,14 @@ describe('request body handling', function () {
         const spec = new Oas(requestBodyRawBody);
         const har = oasToHar(spec, spec.operation('/primitive', 'post'), { body: { RAW_BODY: 'test' } });
 
-        expect(har.log.entries[0].request.postData.text).to.equal(JSON.stringify('test'));
+        expect(har.log.entries[0].request.postData.text).to.equal('test');
       });
 
       it('should return empty for falsy RAW_BODY primitives', function () {
         const spec = new Oas(requestBodyRawBody);
         const har = oasToHar(spec, spec.operation('/primitive', 'post'), { body: { RAW_BODY: '' } });
 
-        expect(har.log.entries[0].request.postData.text).to.equal(JSON.stringify(''));
+        expect(har.log.entries[0].request.postData.text).to.equal('');
       });
 
       it('should work for RAW_BODY json', function () {
@@ -414,6 +414,13 @@ describe('request body handling', function () {
         const har = oasToHar(spec, spec.operation('/objects', 'post'), { body: { RAW_BODY: { a: 'test' } } });
 
         expect(har.log.entries[0].request.postData.text).to.equal(JSON.stringify({ a: 'test' }));
+      });
+
+      it('should work for RAW_BODY objects (but data is a primitive somehow)', function () {
+        const spec = new Oas(requestBodyRawBody);
+        const har = oasToHar(spec, spec.operation('/objects', 'post'), { body: { RAW_BODY: 'test' } });
+
+        expect(har.log.entries[0].request.postData.text).to.equal('test');
       });
 
       it('should return empty for RAW_BODY objects', function () {


### PR DESCRIPTION
## 🧰 Changes

This resolves some more issues with our `RAW_BODY` handling where we were improperly stringifying primitives that didn't need to be stringified, resulting in invalid HAR-generated snippets like the following:

```shell
curl --request POST \
     --url https://httpbin.org/anything/raw_body/top-level-payloads \
     --header 'Content-Type: application/json' \
     --data '"fefef"'
```

## 🧬 QA & Testing

See tests.