### PR TITLE
fix: add handling for when `requestBody` is present w/o a `schema`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -447,7 +447,10 @@ module.exports = (
   // Add a `Content-Type` header if there are any body values setup above or if there is a schema
   // defined, but only do so if we don't already have a `Content-Type` present as it's impossible
   // for a request to have multiple.
-  if ((har.postData.text || (requestBody && Object.keys(requestBody.schema).length)) && !hasContentType) {
+  if (
+    (har.postData.text || (requestBody && requestBody.schema && Object.keys(requestBody.schema).length)) &&
+    !hasContentType
+  ) {
     har.headers.push({
       name: 'Content-Type',
       value: contentType,

--- a/test/requestBody.test.js
+++ b/test/requestBody.test.js
@@ -18,6 +18,26 @@ chai.use(chaiPlugins);
 
 describe('request body handling', function () {
   describe('`body` data handling', function () {
+    it('should not fail if a requestBody is present without a `schema`', function () {
+      const spec = new Oas({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                content: {
+                  'text/plain': {
+                    example: '',
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      expect(oasToHar(spec, spec.operation('/requestBody', 'post')).log.entries[0].request.postData).to.be.undefined;
+    });
+
     it('should not add on empty unrequired values', function () {
       const spec = new Oas({
         paths: {


### PR DESCRIPTION
## 🧰 Changes

We already have handling for this further up in the library but not at this particular line, and if we have a spec right now that has a `requestBody` but no `schema` we're throwing an error.