### PR TITLE
fix: quirk where an auth header may be added twice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -279,6 +279,7 @@ module.exports = (
         hasContentType = true;
         contentType = String(value);
       }
+
       appendHarValue(har.headers, header.name, value);
     });
   }
@@ -465,6 +466,15 @@ module.exports = (
       Object.keys(schemes).forEach(security => {
         const securityValue = configureSecurity(apiDefinition, auth, security);
         if (!securityValue) {
+          return;
+        }
+
+        // If we've already added this security value then don't add it again.
+        if (
+          har[securityValue.type].find(
+            v => v.name === securityValue.value.name && v.value === securityValue.value.value
+          )
+        ) {
           return;
         }
 

--- a/test/__datasets__/security-quirks.json
+++ b/test/__datasets__/security-quirks.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Security quirks",
+    "version": "1.0.0"
+  },
+  "servers": [{ "url": "https://httpbin.org" }],
+  "security": [
+    { "appId": [], "accessToken": [] },
+    { "orgId": [], "accessToken": [] }
+  ],
+  "paths": {
+    "/anything": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "accessToken": {
+        "type": "apiKey",
+        "name": "Access-Token",
+        "in": "header"
+      },
+      "orgId": {
+        "type": "apiKey",
+        "name": "organization_id",
+        "in": "query"
+      },
+      "appId": {
+        "type": "apiKey",
+        "name": "app_id",
+        "in": "query"
+      }
+    }
+  }
+}


### PR DESCRIPTION
| 🚥 Fix RM-4312 |
| :-- |

## 🧰 Changes

This fixes a quirk in our security auth handling where if an API had OR auth requirements, each containing multiple forms of auth, and you specified auth for one of those, and the other contained one of the other, we'd add the same security requirement into the HAR twice.

## 🧬 QA & Testing

For example, with this global secuirty requirement:

```
"security": [
  { "appId": [], "accessToken": [] },
  { "orgId": [], "accessToken": [] }
],
```

If you specified `appId` and `accessToken` we'd add those into the HAR as expected, but we'd also look at the `orgId` and `accessToken` combo and because you didn't specify `orgId` we wouldn't add that, but because you did `accessToken` then `accessToken` would be added into the HAR again, resulting in a HAR `headers` declaration that looked like this:

```
[
  {
    name: 'Access-Token',
    value: 'e229822e-f625-45eb-a963-4d197d29637b',
  },
  {
    name: 'Access-Token',
    value: 'e229822e-f625-45eb-a963-4d197d29637b',
  },
]
```

Which when you feed that HAR into [fetch-har](https://npm.im/fetch-har) to make a request would send `Access-Token` twice:

![Screen Shot 2022-06-15 at 2 37 18 PM](https://user-images.githubusercontent.com/33762/173934297-b011cf7d-65a5-4e1d-bcb0-d9a5cff7fb9e.png)