### PR TITLE
fix: quirk in basic auth handling where it expected a username to be present

### DIFF
--- a/src/lib/configure-security.js
+++ b/src/lib/configure-security.js
@@ -17,7 +17,11 @@ module.exports = function configureSecurity(apiDefinition, values, scheme) {
       if (!values[scheme]) return false;
       if (!values[scheme].user && !values[scheme].pass) return false;
 
-      const user = values[scheme].user;
+      let user = values[scheme].user;
+      if (user === null || user.length === 0) {
+        user = '';
+      }
+
       let pass = values[scheme].pass;
       if (pass === null || pass.length === 0) {
         pass = '';

--- a/test/lib/configure-security.test.js
+++ b/test/lib/configure-security.test.js
@@ -57,6 +57,27 @@ describe('configure-security', function () {
         });
       });
 
+      it('should work if a password is present but the username is empty or null', function () {
+        const user = null;
+        const pass = 'pass';
+
+        expect(
+          configureSecurity(
+            {
+              components: { securitySchemes: { schemeName: { type: 'http', scheme: 'basic' } } },
+            },
+            { schemeName: { user, pass } },
+            'schemeName'
+          )
+        ).to.deep.equal({
+          type: 'headers',
+          value: {
+            name: 'Authorization',
+            value: `Basic ${Buffer.from(`:${pass}`).toString('base64')}`,
+          },
+        });
+      });
+
       it('should work if the password is empty or null', function () {
         const user = 'user';
         const pass = null;


### PR DESCRIPTION
| 🚥 Fix RM-4722 |
| :-- |

## 🧰 Changes

This fixes a bug in our handling of basic auth where if you had a nullish `username` but still a `password` we'd generate the basic auth base64 as `base64(null:password)` instead of `base64(:password)`.

## 🧬 QA & Testing

See tests.