### PR TITLE
fix: weird mess with instanceof checks not always working

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,12 @@ module.exports = (
   }
 ) => {
   let operation = operationSchema;
-  if (!(operationSchema instanceof Operation)) {
+  if (typeof operationSchema.getParameters !== 'function') {
+    // If `operationSchema` was supplied as a plain object instead of an instance of `Operation`
+    // then we should create a new instance of it. We're doing it with a check on `getParameters`
+    // instead of checking `instanceof Operation` because JS is very weird when it comes to checking
+    // `instanceof` against classes. One instance of `Operation` may not always match up with
+    // another if they're being loaded between two different libraries. It's weird. This is easier.
     operation = new Operation(oas, operationSchema.path, operationSchema.method, operationSchema);
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,6 +37,38 @@ describe('oas-to-har', function () {
     });
   });
 
+  it('should create an Operation instance if supplied a plain object', async function () {
+    const spec = new Oas(petstore);
+    await spec.dereference();
+
+    const operation = { method: 'post', path: '/pet' };
+    const har = oasToHar(spec, operation);
+
+    await expect(har).to.be.a.har;
+    expect(har).to.deep.equal({
+      log: {
+        entries: [
+          {
+            request: {
+              cookies: [],
+              headers: [
+                // `POST /pet` normally has `Content-Type: application/json` headers but because we
+                // didn't supply `oas-to-har` with the full schema of `POST /pet` we don't have
+                // this information.
+              ],
+              headersSize: 0,
+              queryString: [],
+              bodySize: 0,
+              method: 'POST',
+              url: 'http://petstore.swagger.io/v2/pet',
+              httpVersion: 'HTTP/1.1',
+            },
+          },
+        ],
+      },
+    });
+  });
+
   it('should accept an Operation instance as the operation schema', async function () {
     const spec = new Oas(petstore);
     await spec.dereference();


### PR DESCRIPTION
## 🧰 Changes

We have a weird issue in `api` where when we pass a real `Operation` instance into `oas-to-har` it doesn't think we passed one in because the `instanceof Operation` check doesn't think it matches `oas-to-har`'s `Operation` despite the library being the same.

So instead of messing around with `instanceof` checks I'm just checking if `Operation.getParameters()` is a thing because if it isn't then we don't have an `Operation` instance.

✨ javascript ✨ 