### PR TITLE
fix: support for filenames that have underscores in them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "17.1.0",
       "license": "ISC",
       "dependencies": {
+        "@readme/data-urls": "^1.0.0",
         "@readme/oas-extensions": "^14.3.0",
         "oas": "^18.3.1",
-        "parse-data-url": "^4.0.1",
         "qs": "^6.10.5",
         "remove-undefined-objects": "^2.0.0"
       },
@@ -2708,6 +2708,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@readme/data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-daQE56+udhu9TmvKeQ5O5gQDEJO/ZAx2KLFjZSczTmZTFk8rvAxSBrKY5LxeZ9DxaGxH+VDx2gvpN0BKLkYY+w==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@readme/eslint-config": {
@@ -14035,17 +14043,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/parse-data-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-4.0.1.tgz",
-      "integrity": "sha512-W+ZgeHPkG2Awbj2RCGG3zALoKGoKucIWXRp8jPgTVNmRgiftXbwXXzzaXXH4L1+OdxeSXC6C8G+hzlcv41f24A==",
-      "dependencies": {
-        "valid-data-url": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -17641,14 +17638,6 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
-    "node_modules/valid-data-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-4.0.0.tgz",
-      "integrity": "sha512-mV5E0AG/F2yPiJzYlhyooI83BLIV0i4h/ueZwdxr1Mh8ZeKKpcFZLbZbAAedL/PLd11sqIgppJBrb4SNXA0PMQ==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -20763,6 +20752,11 @@
           }
         }
       }
+    },
+    "@readme/data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-daQE56+udhu9TmvKeQ5O5gQDEJO/ZAx2KLFjZSczTmZTFk8rvAxSBrKY5LxeZ9DxaGxH+VDx2gvpN0BKLkYY+w=="
     },
     "@readme/eslint-config": {
       "version": "9.0.0",
@@ -29751,14 +29745,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-data-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-data-url/-/parse-data-url-4.0.1.tgz",
-      "integrity": "sha512-W+ZgeHPkG2Awbj2RCGG3zALoKGoKucIWXRp8jPgTVNmRgiftXbwXXzzaXXH4L1+OdxeSXC6C8G+hzlcv41f24A==",
-      "requires": {
-        "valid-data-url": "^4.0.0"
-      }
-    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -32682,11 +32668,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "valid-data-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-4.0.0.tgz",
-      "integrity": "sha512-mV5E0AG/F2yPiJzYlhyooI83BLIV0i4h/ueZwdxr1Mh8ZeKKpcFZLbZbAAedL/PLd11sqIgppJBrb4SNXA0PMQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "test": "nyc mocha"
   },
   "dependencies": {
+    "@readme/data-urls": "^1.0.0",
     "@readme/oas-extensions": "^14.3.0",
     "oas": "^18.3.1",
-    "parse-data-url": "^4.0.1",
     "qs": "^6.10.5",
     "remove-undefined-objects": "^2.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const extensions = require('@readme/oas-extensions');
 const { Operation, utils } = require('oas');
-const parseDataUrl = require('parse-data-url');
+const { parse: parseDataUrl } = require('@readme/data-urls');
 const { default: removeUndefinedObjects } = require('remove-undefined-objects');
 
 const configureSecurity = require('./lib/configure-security');

--- a/test/requestBody.test.js
+++ b/test/requestBody.test.js
@@ -8,6 +8,7 @@ const oasToHar = require('../src');
 const chaiPlugins = require('./helpers/chai-plugins');
 
 const schemaTypes = require('@readme/oas-examples/3.0/json/schema-types.json');
+const fileUploads = require('@readme/oas-examples/3.0/json/file-uploads.json');
 const multipartFormData = require('./__datasets__/multipart-form-data.json');
 const multipartFormDataArrayOfFiles = require('./__datasets__/multipart-form-data/array-of-files.json');
 const requestBodyRawBody = require('./__datasets__/requestBody-raw_body.json');
@@ -532,6 +533,27 @@ describe('request body handling', function () {
                 value: owlbertShrubDataURL,
                 fileName: 'owlbert-shrub.png',
                 contentType: 'image/png',
+              },
+            ],
+          });
+        });
+
+        it('should handle a file that has an underscore in its name', function () {
+          const fixture = new Oas(fileUploads);
+          const har = oasToHar(fixture, fixture.operation('/anything/multipart-formdata', 'post'), {
+            body: {
+              documentFile: 'data:text/plain;name=lorem_ipsum.txt;base64,TG9yZW0gaXBzdW0gZG9sb3Igc2l0IG1ldA==',
+            },
+          });
+
+          expect(har.log.entries[0].request.postData).to.deep.equal({
+            mimeType: 'multipart/form-data',
+            params: [
+              {
+                fileName: 'lorem_ipsum.txt',
+                contentType: 'text/plain',
+                name: 'documentFile',
+                value: 'data:text/plain;name=lorem_ipsum.txt;base64,TG9yZW0gaXBzdW0gZG9sb3Igc2l0IG1ldA==',
               },
             ],
           });


### PR DESCRIPTION
| 🚥 Fix RM-3195 |
| :-- |

## 🧰 Changes

There's a bug in [valid-data-url](https://npm.im/valid-data-url) where it doesn't recognize data URLs that have underscores as being valid. They are!

I've submitted a fix upstream but in the meantime instead of waiting for that to be merged, published, and then merged into [parse-data-url](https://npm.im/parse-data-url), and published, I've soft forked both libraries and merged them into [@readme/data-urls](https://npm.im/@readme/data-urls).