### PR TITLE
feat: lowercasing headers we add so we're compatible with http2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -338,12 +338,12 @@ export default function oasToHar(
       const content = (operation.schema.responses[response] as ResponseObject).content;
       if (!content) return false;
 
-      // If there's no `Accept` header present we should add one so their eventual code snippet
+      // If there's no `accept` header present we should add one so their eventual code snippet
       // follows best practices.
       if (Object.keys(formData.header).find(h => h.toLowerCase() === 'accept')) return true;
 
       har.headers.push({
-        name: 'Accept',
+        name: 'accept',
         value: getResponseContentType(content),
       });
 
@@ -385,12 +385,12 @@ export default function oasToHar(
     });
   }
 
-  // Do we have an `Accept` header set up in the form, but it hasn't been added yet?
+  // Do we have an `accept` header set up in the form, but it hasn't been added yet?
   if (formData.header) {
     const acceptHeader = Object.keys(formData.header).find(h => h.toLowerCase() === 'accept');
     if (acceptHeader && !har.headers.find(hdr => hdr.name.toLowerCase() === 'accept')) {
       har.headers.push({
-        name: 'Accept',
+        name: 'accept',
         value: String(formData.header[acceptHeader]),
       });
     }
@@ -563,15 +563,15 @@ export default function oasToHar(
     }
   }
 
-  // Add a `Content-Type` header if there are any body values setup above or if there is a schema
-  // defined, but only do so if we don't already have a `Content-Type` present as it's impossible
+  // Add a `content-type` header if there are any body values setup above or if there is a schema
+  // defined, but only do so if we don't already have a `content-type` present as it's impossible
   // for a request to have multiple.
   if (
     (har.postData.text || (requestBody && requestBody.schema && Object.keys(requestBody.schema).length)) &&
     !hasContentType
   ) {
     har.headers.push({
-      name: 'Content-Type',
+      name: 'content-type',
       value: contentType,
     });
   }

--- a/src/lib/configure-security.ts
+++ b/src/lib/configure-security.ts
@@ -43,14 +43,14 @@ export default function configureSecurity(apiDefinition: OASDocument, values: Au
       }
 
       return harValue('headers', {
-        name: 'Authorization',
+        name: 'authorization',
         value: `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`,
       });
     } else if (security.scheme === 'bearer') {
       if (!values[scheme]) return false;
 
       return harValue('headers', {
-        name: 'Authorization',
+        name: 'authorization',
         value: `Bearer ${values[scheme]}`,
       });
     }
@@ -88,7 +88,7 @@ export default function configureSecurity(apiDefinition: OASDocument, values: Au
     if (!values[scheme]) return false;
 
     return harValue('headers', {
-      name: 'Authorization',
+      name: 'authorization',
       value: `Bearer ${values[scheme]}`,
     });
   }

--- a/src/lib/style-formatting/index.ts
+++ b/src/lib/style-formatting/index.ts
@@ -67,7 +67,7 @@ function stylizeValue(value: unknown, parameter: ParameterObject) {
   }
 
   /**
-   * Eventhough `Accept`, `Authorization`, and `Content-Type` headers can be defined as parameters,
+   * Eventhough `accept`, `authorization`, and `content-type` headers can be defined as parameters,
    * they should be completely ignored when it comes to serialization.
    *
    *  > If `in` is "header" and the `name` field is "Accept", "Content-Type" or "Authorization", the

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -83,7 +83,7 @@ describe('oas-to-har', function () {
           {
             request: {
               cookies: [],
-              headers: [{ name: 'Content-Type', value: 'application/json' }],
+              headers: [{ name: 'content-type', value: 'application/json' }],
               headersSize: 0,
               queryString: [],
               bodySize: 0,

--- a/test/lib/configure-security.test.ts
+++ b/test/lib/configure-security.test.ts
@@ -37,7 +37,7 @@ describe('configure-security', function () {
         expect(configureSecurity(spec, { busterAuth: { user, pass } }, 'busterAuth')).to.deep.equal({
           type: 'headers',
           value: {
-            name: 'Authorization',
+            name: 'authorization',
             value: `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`,
           },
         });
@@ -51,7 +51,7 @@ describe('configure-security', function () {
         expect(configureSecurity(spec, { busterAuth: { user, pass } }, 'busterAuth')).to.deep.equal({
           type: 'headers',
           value: {
-            name: 'Authorization',
+            name: 'authorization',
             value: `Basic ${Buffer.from(`:${pass}`).toString('base64')}`,
           },
         });
@@ -65,7 +65,7 @@ describe('configure-security', function () {
         expect(configureSecurity(spec, { busterAuth: { user, pass } }, 'busterAuth')).to.deep.equal({
           type: 'headers',
           value: {
-            name: 'Authorization',
+            name: 'authorization',
             value: `Basic ${Buffer.from(`${user}:`).toString('base64')}`,
           },
         });
@@ -90,7 +90,7 @@ describe('configure-security', function () {
         expect(configureSecurity(spec, { busterAuth: { user, pass: '' } }, 'busterAuth')).to.deep.equal({
           type: 'headers',
           value: {
-            name: 'Authorization',
+            name: 'authorization',
             value: `Basic ${Buffer.from(`${user}:`).toString('base64')}`,
           },
         });
@@ -105,7 +105,7 @@ describe('configure-security', function () {
         expect(configureSecurity(spec, { busterAuth: apiKey }, 'busterAuth')).to.deep.equal({
           type: 'headers',
           value: {
-            name: 'Authorization',
+            name: 'authorization',
             value: `Bearer ${apiKey}`,
           },
         });
@@ -138,7 +138,7 @@ describe('configure-security', function () {
       expect(configureSecurity(spec, { busterAuth: apiKey }, 'busterAuth')).to.deep.equal({
         type: 'headers',
         value: {
-          name: 'Authorization',
+          name: 'authorization',
           value: `Bearer ${apiKey}`,
         },
       });

--- a/test/lib/style-formatting/index.test.ts
+++ b/test/lib/style-formatting/index.test.ts
@@ -1046,7 +1046,7 @@ describe('style formatting', function () {
     );
 
     /**
-     * Eventhough `Accept`, `Authorization`, and `Content-Type` headers can be defined as path
+     * Eventhough `accept`, `authorization`, and `content-type` headers can be defined as path
      * parameters, they should be completely ignored when it comes to serialization.
      *
      *  > If `in` is "header" and the `name` field is "Accept", "Content-Type" or "Authorization",
@@ -1057,11 +1057,11 @@ describe('style formatting', function () {
     describe('should ignore styling definitions on OAS-level handled headers', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
       [
-        ['`accept`', 'accept', 'application/json'],
-        ['`content-type`', 'content-type', 'application/json'],
-        ['`authorization`', 'authorization', 'scheme d9b23eb/0df'],
-      ].forEach(([test, headerName, value]) => {
-        it(test, async function () {
+        ['accept', 'application/json'],
+        ['content-type', 'application/json'],
+        ['authorization', 'scheme d9b23eb/0df'],
+      ].forEach(([headerName, value]) => {
+        it(headerName, async function () {
           const oas = createOas('/header', {
             parameters: [
               {

--- a/test/parameters.test.ts
+++ b/test/parameters.test.ts
@@ -412,7 +412,7 @@ describe('parameter handling', function () {
     );
 
     it(
-      'should pass `Accept`  header if endpoint expects a content back from response',
+      'should pass `accept`  header if endpoint expects a content back from response',
       assertHeaders(
         {
           parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
@@ -428,14 +428,14 @@ describe('parameter handling', function () {
         },
         {},
         [
-          { name: 'Accept', value: 'application/xml' },
+          { name: 'accept', value: 'application/xml' },
           { name: 'a', value: 'value' },
         ]
       )
     );
 
     it(
-      'should only add one `Accept` header when multiple responses are present',
+      'should only add one `accept` header when multiple responses are present',
       assertHeaders(
         {
           responses: {
@@ -454,12 +454,12 @@ describe('parameter handling', function () {
           },
         },
         {},
-        [{ name: 'Accept', value: 'application/xml' }]
+        [{ name: 'accept', value: 'application/xml' }]
       )
     );
 
     it(
-      'should only receive one `Accept` header if specified in values',
+      'should only receive one `accept` header if specified in values',
       assertHeaders(
         {
           parameters: [{ name: 'accept', in: 'header' }],
@@ -479,7 +479,7 @@ describe('parameter handling', function () {
     );
 
     it(
-      'should add `Accept` header if specified in formdata',
+      'should add `accept` header if specified in formdata',
       assertHeaders(
         {
           responses: {
@@ -493,7 +493,7 @@ describe('parameter handling', function () {
           },
         },
         { header: { accept: 'application/xml' } },
-        [{ name: 'Accept', value: 'application/xml' }]
+        [{ name: 'accept', value: 'application/xml' }]
       )
     );
 

--- a/test/requestBody.test.ts
+++ b/test/requestBody.test.ts
@@ -459,7 +459,7 @@ describe('request body handling', function () {
           });
 
           expect(har.log.entries[0].request.headers).to.deep.equal([
-            { name: 'Content-Type', value: 'multipart/form-data' },
+            { name: 'content-type', value: 'multipart/form-data' },
           ]);
 
           expect(har.log.entries[0].request.postData).to.deep.equal({
@@ -490,7 +490,7 @@ describe('request body handling', function () {
           });
 
           expect(har.log.entries[0].request.headers).to.deep.equal([
-            { name: 'Content-Type', value: 'multipart/form-data' },
+            { name: 'content-type', value: 'multipart/form-data' },
           ]);
 
           expect(har.log.entries[0].request.postData).to.deep.equal({
@@ -1021,26 +1021,26 @@ describe('request body handling', function () {
       let har = oasToHar(spec, spec.operation('/requestBody', 'post'), {});
       await expect(har).to.be.a.har;
 
-      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'Content-Type', value: 'application/json' }]);
+      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'content-type', value: 'application/json' }]);
 
       har = oasToHar(spec, spec.operation('/requestBody', 'post'), { query: { a: 1 } });
       await expect(har).to.be.a.har;
 
-      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'Content-Type', value: 'application/json' }]);
+      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'content-type', value: 'application/json' }]);
     });
 
     it('should be sent through if there are any body values', async function () {
       const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { a: 'test' } });
       await expect(har).to.be.a.har;
 
-      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'Content-Type', value: 'application/json' }]);
+      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'content-type', value: 'application/json' }]);
     });
 
     it('should be sent through if there are any formData values', async function () {
       const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { formData: { a: 'test' } });
       await expect(har).to.be.a.har;
 
-      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'Content-Type', value: 'application/json' }]);
+      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'content-type', value: 'application/json' }]);
     });
 
     it('should fetch the type from the first `requestBody.content` and first `responseBody.content` object', async function () {
@@ -1072,7 +1072,7 @@ describe('request body handling', function () {
       const har = oasToHar(contentSpec, contentSpec.operation('/requestBody', 'post'), { body: { a: 'test' } });
       await expect(har).to.be.a.har;
 
-      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'Content-Type', value: 'text/xml' }]);
+      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'content-type', value: 'text/xml' }]);
       expect(har.log.entries[0].request.postData.mimeType).to.equal('text/xml');
     });
 
@@ -1118,10 +1118,10 @@ describe('request body handling', function () {
       const har = oasToHar(contentSpec, contentSpec.operation('/requestBody', 'post'), { body: { a: 'test' } });
       await expect(har).to.be.a.har;
 
-      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'Content-Type', value: 'application/json' }]);
+      expect(har.log.entries[0].request.headers).to.deep.equal([{ name: 'content-type', value: 'application/json' }]);
     });
 
-    it("should only add a content-type if one isn't already present", async function () {
+    it("should only add a `content-type` if one isn't already present", async function () {
       const contentSpec = Oas.init({
         paths: {
           '/requestBody': {
@@ -1146,18 +1146,18 @@ describe('request body handling', function () {
           },
         },
         'x-readme': {
-          [extensions.HEADERS]: [{ key: 'Content-Type', value: 'multipart/form-data' }],
+          [extensions.HEADERS]: [{ key: 'content-type', value: 'multipart/form-data' }],
         },
       });
 
       const har = oasToHar(contentSpec, contentSpec.operation('/requestBody', 'post'), { body: { a: 'test' } });
       await expect(har).to.be.a.har;
 
-      // `Content-Type: application/json` would normally appear here if there were no
+      // `content-type: application/json` would normally appear here if there were no
       // `x-readme.headers`, but since there is we should default to that so as to we don't double
-      // up on Content-Type headers.
+      // up on `content-type` headers.
       expect(har.log.entries[0].request.headers).to.deep.equal([
-        { name: 'Content-Type', value: 'multipart/form-data' },
+        { name: 'content-type', value: 'multipart/form-data' },
       ]);
 
       expect(har.log.entries[0].request.postData.mimeType).to.equal('multipart/form-data');


### PR DESCRIPTION
| 🚥 Fix RM-5197 |
| :-- |

## 🧰 Changes

Though headers on HTTP/1.1 are case-insensitive on HTTP/2 they [must be lowercased](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2). 

> HTTP header fields carry information as a series of key-value pairs. For a listing of registered HTTP headers, see the "Message Header Field" registry maintained at <[https://www.iana.org/assignments/](https://www.iana.org/assignments/message-headers)[message-headers](https://www.iana.org/assignments/message-headers)>.
>
> Just as in HTTP/1.x, header field names are strings of ASCII characters that are compared in a case-insensitive fashion.  However, header field names MUST be converted to lowercase prior to their encoding in HTTP/2.  A request or response containing uppercase header field names MUST be treated as malformed ([Section 8.1.2.6](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.6)).

The `Accept`, `Authorization`, and `Content-Type` headers that this library adds were always going in in that casing, and because we have no way of inferring from an OAS if that API uses HTTP/2 we're converting them to lowercase for all users. Because HTTP/1.1 is case-insensitive this change should be non-breaking.