### PR TITLE
fix: issue where auth header may be sent twice

### DIFF
--- a/src/lib/configure-security.ts
+++ b/src/lib/configure-security.ts
@@ -21,23 +21,23 @@ export default function configureSecurity(apiDefinition: OASDocument, values: Au
 
   if (isRef(security)) {
     return undefined;
+  } else if (!values[scheme]) {
+    // If we don't have any data for this auth scheme then we shouldn't add it.
+    return false;
   }
 
   if (security.type === 'http') {
     if (security.scheme === 'basic') {
-      // Return with no header if user and password are blank
-      if (!values[scheme]) return false;
-
       const auth = values[scheme];
       if (typeof auth !== 'object') return false;
       if (!auth.user && !auth.pass) return false;
 
-      let user = auth.user;
+      let user = auth.user ?? null;
       if (user === null || user.length === 0) {
         user = '';
       }
 
-      let pass = auth.pass;
+      let pass = auth.pass ?? null;
       if (pass === null || pass.length === 0) {
         pass = '';
       }
@@ -47,8 +47,6 @@ export default function configureSecurity(apiDefinition: OASDocument, values: Au
         value: `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`,
       });
     } else if (security.scheme === 'bearer') {
-      if (!values[scheme]) return false;
-
       return harValue('headers', {
         name: 'authorization',
         value: `Bearer ${values[scheme]}`,
@@ -85,8 +83,6 @@ export default function configureSecurity(apiDefinition: OASDocument, values: Au
   }
 
   if (security.type === 'oauth2') {
-    if (!values[scheme]) return false;
-
     return harValue('headers', {
       name: 'authorization',
       value: `Bearer ${values[scheme]}`,

--- a/test/__datasets__/security-quirks.json
+++ b/test/__datasets__/security-quirks.json
@@ -5,13 +5,26 @@
     "version": "1.0.0"
   },
   "servers": [{ "url": "https://httpbin.org" }],
-  "security": [
-    { "appId": [], "accessToken": [] },
-    { "orgId": [], "accessToken": [] }
-  ],
   "paths": {
     "/anything": {
       "post": {
+        "description": "If an endpoint can accept two forms of auth, with one of those schemes being used in another potential form, and we specify one of these options, we should not add the scheme that can be used twice twice into the HAR.",
+        "security": [
+          { "appId": [], "accessToken": [] },
+          { "orgId": [], "accessToken": [] }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "description": "If an endpoint can accept either Basic or OAuth Bearer auth, and the user supplies data for one of those, we should only add one `authorization` header into the mix.",
+        "security": [
+          { "Basic": [] },
+          { "Bearer": [] }
+        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -36,6 +49,15 @@
         "type": "apiKey",
         "name": "app_id",
         "in": "query"
+      },
+      "Bearer": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header"
+      },
+      "Basic": {
+        "type": "http",
+        "scheme": "basic"
       }
     }
   }

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -21,7 +21,7 @@ describe('auth handling', function () {
       ]);
     });
 
-    it('should not send the same auth header twice', function () {
+    it('should not send the same auth header twice if an auth scheme can be used in multiple ways', function () {
       const auth = {
         appId: '1234567890',
         accessToken: 'e229822e-f625-45eb-a963-4d197d29637b',
@@ -34,6 +34,20 @@ describe('auth handling', function () {
         {
           name: 'Access-Token',
           value: 'e229822e-f625-45eb-a963-4d197d29637b',
+        },
+      ]);
+    });
+
+    it('should not send the same header twice if only one form of auth is present', function () {
+      const auth = { Basic: { pass: 'buster' } };
+
+      const oas = Oas.init(securityQuirks);
+      const har = oasToHar(oas, oas.operation('/anything', 'put'), {}, auth);
+
+      expect(har.log.entries[0].request.headers).to.deep.equal([
+        {
+          name: 'authorization',
+          value: 'Basic OmJ1c3Rlcg==',
         },
       ]);
     });

--- a/test/lib/configure-security.test.ts
+++ b/test/lib/configure-security.test.ts
@@ -29,45 +29,36 @@ describe('configure-security', function () {
 
   describe('http auth support', function () {
     describe('type=basic', function () {
-      it('should work for basic type', function () {
-        const user = 'user';
-        const pass = 'pass';
-        const spec = createSecurityOAS({ type: 'http', scheme: 'basic' });
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        ['should work for basic type', { user: 'user', pass: 'pass' }, 'user:pass'],
+        [
+          'should work if a password is present but the username is undefined',
+          { user: undefined, pass: 'pass' },
+          ':pass',
+        ],
+        ['should work if a password is present but the username is null', { user: null, pass: 'pass' }, ':pass'],
+        [
+          'should work if a password is present but the username is an empty string',
+          { user: '', pass: 'pass' },
+          ':pass',
+        ],
+        ['should work if a username is present but the pass is undefined', { user: 'user', pass: undefined }, 'user:'],
+        ['should work if a username is present but the pass is null', { user: 'user', pass: null }, 'user:'],
+        ['should work if a username is present but the pass is an empty string', { user: 'user', pass: '' }, 'user:'],
+      ].forEach(([_, auth, expected]: [string, { user: string; pass: string }, string]) => {
+        it(_, function () {
+          const user = auth.user;
+          const pass = auth.pass;
+          const spec = createSecurityOAS({ type: 'http', scheme: 'basic' });
 
-        expect(configureSecurity(spec, { busterAuth: { user, pass } }, 'busterAuth')).to.deep.equal({
-          type: 'headers',
-          value: {
-            name: 'authorization',
-            value: `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`,
-          },
-        });
-      });
-
-      it('should work if a password is present but the username is empty or null', function () {
-        const user = null;
-        const pass = 'pass';
-        const spec = createSecurityOAS({ type: 'http', scheme: 'basic' });
-
-        expect(configureSecurity(spec, { busterAuth: { user, pass } }, 'busterAuth')).to.deep.equal({
-          type: 'headers',
-          value: {
-            name: 'authorization',
-            value: `Basic ${Buffer.from(`:${pass}`).toString('base64')}`,
-          },
-        });
-      });
-
-      it('should work if the password is empty or null', function () {
-        const user = 'user';
-        const pass = null;
-        const spec = createSecurityOAS({ type: 'http', scheme: 'basic' });
-
-        expect(configureSecurity(spec, { busterAuth: { user, pass } }, 'busterAuth')).to.deep.equal({
-          type: 'headers',
-          value: {
-            name: 'authorization',
-            value: `Basic ${Buffer.from(`${user}:`).toString('base64')}`,
-          },
+          expect(configureSecurity(spec, { busterAuth: { user, pass } }, 'busterAuth')).to.deep.equal({
+            type: 'headers',
+            value: {
+              name: 'authorization',
+              value: `Basic ${Buffer.from(expected).toString('base64')}`,
+            },
+          });
         });
       });
 


### PR DESCRIPTION
| 🚥 Fix RM-5081 |
| :-- |

## 🧰 Changes

This fixes a problem in our `authorization` header construction where if an endpoint accepted either Basic or Bearer auth, and only specified data for the Basic auth portion, we'd add the `authorization` header twice: once with their data, and once with `undefined` as the value.

This would ultiumately bubble up into [@readme/oas-to-snippet](https://npm.im/@readme/oas-to-snippet) where we'd only show `authorization: undefined` in the code snippet:

![Screen Shot 2022-09-07 at 12 38 25 PM](https://user-images.githubusercontent.com/33762/188962621-4b01b526-6565-4b5c-88d5-2249bc656de7.png)