### PR TITLE
fix: preferring JSON response content accept headers over everything else

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,9 @@
     "@readme/eslint-config",
     "@readme/eslint-config/typescript"
   ],
-  "root": true
+  "root": true,
+  "rules": {
+    // `any` types are fine because we're dealing with a lot of unknown data.
+    "@typescript-eslint/no-explicit-any": "off"
+  }
 }

--- a/test/parameters.test.ts
+++ b/test/parameters.test.ts
@@ -412,7 +412,30 @@ describe('parameter handling', function () {
     );
 
     it(
-      'should pass `accept`  header if endpoint expects a content back from response',
+      'should pass `accept` header if endpoint expects a content back from response',
+      assertHeaders(
+        {
+          parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
+          responses: {
+            200: {
+              description: 'ok',
+              content: {
+                'application/xml': { schema: { type: 'array', items: {} } },
+                'text/plain': { schema: { type: 'array', items: {} } },
+              },
+            },
+          },
+        },
+        {},
+        [
+          { name: 'accept', value: 'application/xml' },
+          { name: 'a', value: 'value' },
+        ]
+      )
+    );
+
+    it(
+      'should pass `accept` header if endpoint expects a content back from response, but prioritize JSON',
       assertHeaders(
         {
           parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
@@ -428,7 +451,7 @@ describe('parameter handling', function () {
         },
         {},
         [
-          { name: 'accept', value: 'application/xml' },
+          { name: 'accept', value: 'application/json' },
           { name: 'a', value: 'value' },
         ]
       )


### PR DESCRIPTION
## 🧰 Changes

In order to allow `Accept` headers to be sent in api (https://github.com/readmeio/api/issues/448), I need to fix this issue where we're always returning the `Accept` header for a HAR as the first defined content type. Since we prefer JSON for everything else it makes sense to also prefer a JSON response.

I'm not considering this to be a breaking change.