### PR TITLE
feat: ability to manually specify an `authorization` header in formData

### DIFF
--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -51,6 +51,29 @@ describe('auth handling', function () {
         },
       ]);
     });
+
+    it('should send a manually-defined auth header, overriding any supplied auth data, if `authorization` is present in the header data', function () {
+      const auth = { Basic: { pass: 'buster' } };
+
+      const oas = Oas.init(securityQuirks);
+      const har = oasToHar(
+        oas,
+        oas.operation('/anything', 'put'),
+        {
+          header: {
+            authorization: 'Bearer 1234',
+          },
+        },
+        auth
+      );
+
+      expect(har.log.entries[0].request.headers).to.deep.equal([
+        {
+          name: 'authorization',
+          value: 'Bearer 1234',
+        },
+      ]);
+    });
   });
 
   it('should work for query auth', function () {

--- a/test/parameters.test.ts
+++ b/test/parameters.test.ts
@@ -412,7 +412,7 @@ describe('parameter handling', function () {
     );
 
     it(
-      'should pass `accept` header if endpoint expects a content back from response',
+      'should pass an `accept` header if endpoint expects a content back from response',
       assertHeaders(
         {
           parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],
@@ -435,7 +435,7 @@ describe('parameter handling', function () {
     );
 
     it(
-      'should pass `accept` header if endpoint expects a content back from response, but prioritize JSON',
+      'should pass an `accept` header if endpoint expects a content back from response, but prioritize JSON',
       assertHeaders(
         {
           parameters: [{ name: 'a', in: 'header', required: true, schema: { default: 'value' } }],


### PR DESCRIPTION
## 🧰 Changes

Like I did in #130 for `Accept` headers, this allows us to manually specify an `Authorization` header in the form data, bypassing any auth data that's supplied to the library.

Fix in support of RM-4020.