### PR TITLE
fix: quirk with multipart/form-data schema payloads being handled as `text`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -430,7 +430,6 @@ export default function oasToHar(
     }
   }
 
-  // const requestBody = operation.getParametersAsJSONSchema().find(p => p.type === 'body');
   let requestBody: MediaTypeObject;
   if (operation.hasRequestBody()) {
     // @ts-expect-error TODO `requestBody` coming back as `false | MediaTypeObject | [string, MediaTypeObject]` seems like a problem

--- a/test/__datasets__/multipart-form-data/oneOf-requestbody.json
+++ b/test/__datasets__/multipart-form-data/oneOf-requestbody.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "2.0",
+    "title": "multipart/form-data request with `oneOf` payload"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/anything": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "image": {
+                        "type": "string",
+                        "format": "binary"
+                      },
+                      "image_url": {
+                        "type": "string"
+                      },
+                      "image_id": {
+                        "type": "string"
+                      }
+                    },
+                    "oneOf": [
+                      {
+                        "required": ["image"]
+                      },
+                      {
+                        "required": ["image_url"]
+                      },
+                      {
+                        "required": ["image_id"]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "output_type": {
+                        "type": "string",
+                        "default": "cutout",
+                        "enum": ["mask", "cutout"]
+                      },
+                      "bg_image": {
+                        "type": "string",
+                        "format": "binary",
+                        "nullable": true
+                      },
+                      "bg_image_url": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "bg_image_id": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "bg_color": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "bg_blur": {
+                        "type": "integer",
+                        "default": 0,
+                        "minimum": 0,
+                        "maximum": 100
+                      },
+                      "bg_width": {
+                        "type": "integer"
+                      },
+                      "bg_height": {
+                        "type": "integer"
+                      },
+                      "scale": {
+                        "type": "string",
+                        "enum": ["fit", "fill"],
+                        "default": "fit"
+                      },
+                      "format": {
+                        "type": "string",
+                        "enum": ["JPG", "PNG", "WEBP"],
+                        "default": "PNG"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/requestBody.test.ts
+++ b/test/requestBody.test.ts
@@ -7,6 +7,7 @@ import Oas from 'oas';
 import oasToHar from '../src';
 
 import multipartFormDataArrayOfFiles from './__datasets__/multipart-form-data/array-of-files.json';
+import multipartFormDataOneOfRequestBody from './__datasets__/multipart-form-data/oneOf-requestbody.json';
 import multipartFormData from './__datasets__/multipart-form-data.json';
 import owlbertShrubDataURL from './__datasets__/owlbert-shrub.dataurl.json';
 import owlbertDataURL from './__datasets__/owlbert.dataurl.json';
@@ -472,6 +473,38 @@ describe('request body handling', function () {
                 name: 'documentFile',
                 value: owlbertDataURL,
               },
+            ],
+          });
+        });
+
+        it('should handle multipart/form-data requests where the requestBody is a `oneOf`', async function () {
+          const oas = Oas.init(multipartFormDataOneOfRequestBody);
+          await oas.dereference();
+          const operation = oas.operation('/anything', 'post');
+          const values = {
+            body: {
+              output_type: 'cutout',
+              bg_blur: 0,
+              scale: 'fit',
+              format: 'PNG',
+              bg_image: 'fef',
+            },
+          };
+
+          const har = oasToHar(oas, operation, values, {});
+
+          expect(har.log.entries[0].request.headers).toStrictEqual([
+            { name: 'content-type', value: 'multipart/form-data' },
+          ]);
+
+          expect(har.log.entries[0].request.postData).toStrictEqual({
+            mimeType: 'multipart/form-data',
+            params: [
+              { name: 'output_type', value: 'cutout' },
+              { name: 'bg_blur', value: '0' },
+              { name: 'scale', value: 'fit' },
+              { name: 'format', value: 'PNG' },
+              { name: 'bg_image', value: 'fef' },
             ],
           });
         });


### PR DESCRIPTION
| 🚥 Fixes CX-362 |
| :---------------- |

## 🧰 Changes

This fixes a quirk with certain `multipart/form-data` schema shapes where if it were set up as a nested `oneOf` or `anyOf` then the HAR that we would generate would dump everything into `postData.text` instead of `postData.params`. This would further cascade into `@readme/oas-to-snippet` where the snippet we'd generate for these situations would have no parameters because it's expecting those parameters to be in `postData.params`.