### PR TITLE
fix: support for deeply nested `format: json` schemas

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,9 @@
   "root": true,
   "rules": {
     // `any` types are fine because we're dealing with a lot of unknown data.
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+
+    "you-dont-need-lodash-underscore/get": "off",
+    "you-dont-need-lodash-underscore/set": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@readme/data-urls": "^1.0.1",
         "@readme/oas-extensions": "^17.0.1",
+        "lodash": "^4.17.21",
         "oas": "^20.8.7",
         "qs": "^6.11.2",
         "remove-undefined-objects": "^3.0.0"
@@ -22,6 +23,7 @@
         "@readme/oas-examples": "^5.11.1",
         "@types/har-format": "^1.2.11",
         "@types/jest": "^29.5.2",
+        "@types/lodash": "^4.14.195",
         "@types/qs": "^6.9.7",
         "eslint": "^8.44.0",
         "har-validator": "^5.1.5",
@@ -2683,6 +2685,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
       "dev": true
     },
     "node_modules/@types/minimist": {
@@ -13560,6 +13568,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
       "dev": true
     },
     "@types/minimist": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@readme/data-urls": "^1.0.1",
     "@readme/oas-extensions": "^17.0.1",
+    "lodash": "^4.17.21",
     "oas": "^20.8.7",
     "qs": "^6.11.2",
     "remove-undefined-objects": "^3.0.0"
@@ -37,6 +38,7 @@
     "@readme/oas-examples": "^5.11.1",
     "@types/har-format": "^1.2.11",
     "@types/jest": "^29.5.2",
+    "@types/lodash": "^4.14.195",
     "@types/qs": "^6.9.7",
     "eslint": "^8.44.0",
     "har-validator": "^5.1.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -435,9 +435,12 @@ export default function oasToHar(
 
   let requestBody: SchemaWrapper;
   if (operation.hasRequestBody()) {
-    requestBody = operation
-      .getParametersAsJSONSchema()
-      .find(p => p.type === (operation.isFormUrlEncoded() ? 'formData' : 'body'));
+    requestBody = operation.getParametersAsJSONSchema().find(payload => {
+      // `formData` is used in our API Explorer for `application/x-www-form-urlencoded` endpoints
+      // and if you have an operation with that, it will only ever have a `formData`. `body` is
+      // used for all other payload shapes.
+      return payload.type === (operation.isFormUrlEncoded() ? 'formData' : 'body');
+    });
   }
 
   if (requestBody && requestBody.schema && Object.keys(requestBody.schema).length) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import type { AuthForHAR } from './lib/configure-security';
 import type { Extensions } from '@readme/oas-extensions';
 import type { PostDataParams, Request } from 'har-format';
 import type Oas from 'oas';
+import type { SchemaWrapper } from 'oas/dist/operation/get-parameters-as-json-schema';
 import type {
   HttpMethods,
   JSONSchema,
@@ -16,12 +17,14 @@ import type {
 
 import { parse as parseDataUrl } from '@readme/data-urls';
 import * as extensions from '@readme/oas-extensions';
+import { get as lodashGet, set as lodashSet } from 'lodash'; // eslint-disable-line no-restricted-imports
 import { Operation, utils } from 'oas';
 import { isRef } from 'oas/dist/rmoas.types';
 import removeUndefinedObjects from 'remove-undefined-objects';
 
 import configureSecurity from './lib/configure-security';
 import formatStyle from './lib/style-formatting';
+import { getTypedFormatsInSchema, hasSchemaType } from './lib/utils';
 
 const { jsonSchemaTypes, matchesMimeType } = utils;
 
@@ -430,10 +433,11 @@ export default function oasToHar(
     }
   }
 
-  let requestBody: MediaTypeObject;
+  let requestBody: SchemaWrapper;
   if (operation.hasRequestBody()) {
-    // @ts-expect-error TODO `requestBody` coming back as `false | MediaTypeObject | [string, MediaTypeObject]` seems like a problem
-    [, requestBody] = operation.getRequestBody();
+    requestBody = operation
+      .getParametersAsJSONSchema()
+      .find(p => p.type === (operation.isFormUrlEncoded() ? 'formData' : 'body'));
   }
 
   if (requestBody && requestBody.schema && Object.keys(requestBody.schema).length) {
@@ -544,16 +548,12 @@ export default function oasToHar(
           } else {
             har.postData.mimeType = contentType;
 
-            /**
-             * Handle arbitrary JSON input via a string.
-             *
-             * In OAS you usually find this in an `application/json` content type with a schema
-             * `type=string, format=json`. In the UI this is represented by an arbitrary text input.
-             *
-             * This ensures we remove any newlines or tabs and use a clean JSON block in the
-             * example.
-             */
-            if ((requestBody.schema as SchemaObject).type === 'string') {
+            if (
+              hasSchemaType(requestBody.schema, 'string') ||
+              hasSchemaType(requestBody.schema, 'integer') ||
+              hasSchemaType(requestBody.schema, 'number') ||
+              hasSchemaType(requestBody.schema, 'boolean')
+            ) {
               har.postData.text = JSON.stringify(JSON.parse(cleanBody));
             } else {
               /**
@@ -564,16 +564,13 @@ export default function oasToHar(
                * of actual objects. We also only want values that the user has entered, so we drop
                * any `undefined` `cleanBody` keys.
                */
-              const jsonTypes = Object.keys(requestBodySchema.properties).filter(key => {
-                const propData = requestBodySchema.properties[key] as JSONSchema;
-                return propData.format === 'json' && cleanBody[key] !== undefined;
-              });
+              const jsonTypes = getTypedFormatsInSchema('json', requestBodySchema.properties, { payload: cleanBody });
 
-              if (jsonTypes.length) {
+              if (Array.isArray(jsonTypes) && jsonTypes.length) {
                 try {
-                  jsonTypes.forEach(prop => {
+                  jsonTypes.forEach((prop: string) => {
                     try {
-                      cleanBody[prop] = JSON.parse(cleanBody[prop]);
+                      lodashSet(cleanBody, prop, JSON.parse(lodashGet(cleanBody, prop)));
                     } catch (e) {
                       // leave the prop as a string value
                     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,124 @@
+import type { JSONSchema, SchemaObject } from 'oas/dist/rmoas.types';
+
+import { get as lodashGet } from 'lodash'; // eslint-disable-line no-restricted-imports
+
+/**
+ * Determine if a schema `type` is, or contains, a specific discriminator.
+ *
+ */
+export function hasSchemaType(
+  schema: SchemaObject,
+  discriminator: 'array' | 'object' | 'string' | 'number' | 'boolean' | 'integer' | 'null'
+) {
+  if (Array.isArray(schema.type)) {
+    return schema.type.includes(discriminator);
+  }
+
+  return schema.type === discriminator;
+}
+
+/**
+ * With a supplied JSON Schema object, spider through it for any schemas that may contain specific
+ * kind of `format` that also happen to be within the current `requestBody` payload that we're
+ * creating a HAR representation for.
+ *
+ */
+export function getTypedFormatsInSchema(
+  format: 'json' | 'binary',
+  schema: any,
+  opts: {
+    parentIsArray?: boolean;
+    parentKey?: string;
+    payload: any;
+  }
+): boolean | string | (string | boolean)[] {
+  try {
+    if (schema?.format === format) {
+      if (opts.parentIsArray) {
+        const parentData = lodashGet(opts.payload, opts.parentKey);
+        if (parentData !== undefined && Array.isArray(parentData)) {
+          return Object.keys(parentData)
+            .map(pdk => {
+              const currentKey = [opts.parentKey, pdk /* , key */].join('.');
+              if (lodashGet(opts.payload, currentKey) !== undefined) {
+                return currentKey;
+              }
+
+              return false;
+            })
+            .filter(Boolean);
+        }
+      } else if (opts.parentKey && lodashGet(opts.payload, opts.parentKey) !== undefined) {
+        return opts.parentKey;
+      } else if (opts.payload !== undefined) {
+        // If this payload is present and we're looking for a specific format then we should assume
+        // that the **root** schema of the request body is that format, and we aren't trafficking in
+        // a nested object or array schema.
+        return true;
+      }
+
+      return false;
+    }
+
+    let subSchemaDataSize = 0;
+    if (opts.parentIsArray) {
+      // If we don't have data for this parent schema in our body payload then we
+      // shouldn't bother spidering further into the schema looking for more `format`s
+      // for data that definitely doesn't exist.
+      const parentData = lodashGet(opts.payload, opts.parentKey);
+      if (parentData === undefined || !Array.isArray(parentData)) {
+        return false;
+      }
+
+      subSchemaDataSize = parentData.length;
+    }
+
+    let subschemas: any[] = [];
+    if (subSchemaDataSize > 0) {
+      for (let idx = 0; idx < subSchemaDataSize; idx += 1) {
+        subschemas = subschemas.concat(
+          Object.entries(schema).map(([key, subschema]: [string, JSONSchema]) => ({
+            key: opts.parentKey ? [opts.parentKey, idx, key].join('.') : key,
+            schema: subschema,
+          }))
+        );
+      }
+    } else {
+      subschemas = Object.entries(schema).map(([key, subschema]: [string, JSONSchema]) => ({
+        key: opts.parentKey ? [opts.parentKey, key].join('.') : key,
+        schema: subschema,
+      }));
+    }
+
+    return subschemas
+      .map(({ key, schema: subschema }) => {
+        if ('properties' in subschema) {
+          return getTypedFormatsInSchema(format, subschema.properties, { payload: opts.payload, parentKey: key });
+        } else if ('items' in subschema) {
+          if ((subschema.items as JSONSchema)?.properties) {
+            return getTypedFormatsInSchema(format, (subschema.items as JSONSchema).properties, {
+              payload: opts.payload,
+              parentKey: key,
+              parentIsArray: true,
+            });
+          }
+
+          return getTypedFormatsInSchema(format, subschema.items, {
+            payload: opts.payload,
+            parentKey: key,
+            parentIsArray: true,
+          });
+        }
+
+        // If this schema has neither `properties` or `items` then it's a regular schema
+        // we can re-run.
+        return getTypedFormatsInSchema(format, subschema, { payload: opts.payload, parentKey: key });
+      })
+      .flat()
+      .filter(Boolean);
+  } catch (err) {
+    // If this fails for whatever reason then we should act as if we didn't find any `format`'d
+    // schemas.
+    return [];
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,7 +39,7 @@ export function getTypedFormatsInSchema(
         if (parentData !== undefined && Array.isArray(parentData)) {
           return Object.keys(parentData)
             .map(pdk => {
-              const currentKey = [opts.parentKey, pdk /* , key */].join('.');
+              const currentKey = [opts.parentKey, pdk].join('.');
               if (lodashGet(opts.payload, currentKey) !== undefined) {
                 return currentKey;
               }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -29,7 +29,7 @@ export function getTypedFormatsInSchema(
   opts: {
     parentIsArray?: boolean;
     parentKey?: string;
-    payload: any;
+    payload: unknown;
   }
 ): boolean | string | (string | boolean)[] {
   try {


### PR DESCRIPTION
| 🚥 Fixes CX-229 |
| :---------------- |

## 🧰 Changes

This fixes a quirk in our handling of schemas with `format: json` where we only supported them if they were at the top-most level in the schema. If you had an object with one of its properties being `format: json`, or an array of objects with the same, that JSON object would be stringified into the HAR we generate.
