### PR TITLE
fix: make `explode:true` default for deepObject styles

### DIFF
--- a/src/lib/style-formatting/index.ts
+++ b/src/lib/style-formatting/index.ts
@@ -215,7 +215,11 @@ function handleExplode(value: any, parameter: ParameterObject) {
 
 function shouldExplode(parameter: ParameterObject) {
   return (
-    (parameter.explode || (parameter.explode !== false && parameter.style === 'form')) &&
+    (parameter.explode ||
+      (parameter.explode !== false && parameter.style === 'form') ||
+      // style: deepObject && explode: false doesn't exist so explode it always
+      // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-examples
+      parameter.style === 'deepObject') &&
     // header and path doesn't explode into separate parameters like query and cookie do
     parameter.in !== 'header' &&
     parameter.in !== 'path'

--- a/test/lib/style-formatting/index.test.ts
+++ b/test/lib/style-formatting/index.test.ts
@@ -2,7 +2,6 @@ import type { DataForHAR } from '../../../src';
 import type { Request } from 'har-format';
 
 import toBeAValidHAR from 'jest-expect-har';
-import Oas from 'oas';
 
 import oasToHar from '../../../src';
 import oasFixture from '../../__fixtures__/create-oas';
@@ -24,13 +23,6 @@ import {
 expect.extend({ toBeAValidHAR });
 
 const createOas = oasFixture('get');
-
-let style: Oas;
-
-beforeAll(async () => {
-  style = await import('@readme/oas-examples/3.0/json/podium.reduced.json').then(r => r.default).then(Oas.init);
-  await style.dereference();
-});
 
 const semicolon = ';'; // %3B when encoded, which we don't want
 const equals = '='; // %3D when encoded, which we don't want
@@ -836,22 +828,13 @@ describe('style formatting', () => {
           const har = oasToHar(oas, oas.operation('/query', 'get'), formData);
           await expect(har).toBeAValidHAR();
 
-          console.log('har', har.log.entries[0]);
-          console.log('oas', oas);
-
           expect(har.log.entries[0].request.queryString).toStrictEqual(expected);
         };
       }
 
-      it('console.log', () => {
-        const har = oasToHar(style, style.operation('/v4/reviews', 'get'), { query: { createdAt: { gt: 'test' } }})
-
-        console.log('har', har.log.entries[0].request);
-      });
-
       it(
         'should NOT support deepObject delimited query styles for non exploded empty input',
-        assertDeepObjectStyle(paramNoExplode, { query: { color: 'emptyInput' } }, [])
+        assertDeepObjectStyle(paramNoExplode, { query: { color: emptyInput } }, [])
       );
 
       it(

--- a/test/lib/style-formatting/index.test.ts
+++ b/test/lib/style-formatting/index.test.ts
@@ -890,7 +890,7 @@ describe('style formatting', () => {
         ])
       );
 
-      it.only(
+      it(
         'should support deepObject delimited query styles for implicit exploded object input',
         assertDeepObjectStyle(paramImplicitExplode, { query: { color: objectInput } }, [
           { name: 'color[R]', value: '100' },


### PR DESCRIPTION
| 🚥 Resolves CX-124 |
| :---------------- |

## 🧰 Changes
Currently, if a customer uses `style: deepObject` but they don't explicitly add `explode: true`, our logic is defaulting `explode: false` which returns `undefined` since `deepObject && explode: false` isn't a thing according to the [spec](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#style-examples). This causes anything the user types in the input to return `undefined`.

I added an extra check in our logic for `shouldExplode()` to ensure that anytime the style is set to `deepObject`, we'll automatically explode the parameter.

## 🧬 QA & Testing
I'll put this into the PR for the main repo too but leaving the info here for visibility sake:


This is what the test looks like before my change:
<img src="https://github.com/readmeio/oas-to-har/assets/41130056/14f9e353-8b9e-407a-9346-e1dd55ec7716" width=40% height=40%>
The `color` object has a value of `undefined` which is overwriting the child properties.

And what it looks like on prod:
<img alt="image" src="https://github.com/readmeio/oas-to-har/assets/41130056/b0c44e9b-a756-4c17-9d57-e4224d70deed" width=66% height=66%>

With this new change, it should correctly explode the parameters as if `explode: true` was explicitly set. 