### PR TITLE
fix: split out type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
       "require": "./dist/lib/configure-security.cjs",
       "import": "./dist/lib/configure-security.js"
     },
+    "./lib/types": {
+      "require": "./dist/lib/types.cjs",
+      "import": "./dist/lib/types.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.cjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { AuthForHAR } from './lib/configure-security';
+import type { AuthForHAR, DataForHAR, oasToHarOptions } from './lib/types';
 import type { Extensions } from '@readme/oas-extensions';
 import type { PostDataParams, Request } from 'har-format';
 import type Oas from 'oas';
@@ -27,20 +27,6 @@ import formatStyle from './lib/style-formatting';
 import { getSafeRequestBody, getTypedFormatsInSchema, hasSchemaType } from './lib/utils';
 
 const { jsonSchemaTypes, matchesMimeType } = utils;
-
-export type { AuthForHAR } from './lib/configure-security';
-export interface DataForHAR {
-  body?: any;
-  cookie?: Record<string, any>;
-  formData?: Record<string, any>; // `application/x-www-form-urlencoded` requests payloads.
-  header?: Record<string, any>;
-  path?: Record<string, any>;
-  query?: Record<string, any>;
-  server?: {
-    selected: number;
-    variables?: Record<string, unknown>;
-  };
-}
 
 function formatter(
   values: DataForHAR,
@@ -229,12 +215,6 @@ function encodeBodyForHAR(body: any) {
   }
 
   return stringify(body);
-}
-
-export interface oasToHarOptions {
-  // If true, the operation URL will be rewritten and prefixed with https://try.readme.io/ in
-  // order to funnel requests through our CORS-friendly proxy.
-  proxyUrl: boolean;
 }
 
 export default function oasToHar(

--- a/src/lib/configure-security.ts
+++ b/src/lib/configure-security.ts
@@ -1,8 +1,7 @@
+import type { AuthForHAR } from './types';
 import type { OASDocument, SecuritySchemeObject } from 'oas/rmoas.types';
 
 import { isRef } from 'oas/rmoas.types';
-
-export type AuthForHAR = Record<string, string | number | { pass?: string; user?: string }>;
 
 function harValue(type: 'cookies' | 'headers' | 'queryString', value: { name: string; value: string }) {
   if (!value.value) return undefined;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,19 @@
+export type AuthForHAR = Record<string, string | number | { pass?: string; user?: string }>;
+
+export interface DataForHAR {
+  body?: any;
+  cookie?: Record<string, any>;
+  formData?: Record<string, any>; // `application/x-www-form-urlencoded` requests payloads.
+  header?: Record<string, any>;
+  path?: Record<string, any>;
+  query?: Record<string, any>;
+  server?: {
+    selected: number;
+    variables?: Record<string, unknown>;
+  };
+}
+export interface oasToHarOptions {
+  // If true, the operation URL will be rewritten and prefixed with https://try.readme.io/ in
+  // order to funnel requests through our CORS-friendly proxy.
+  proxyUrl: boolean;
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig(options => ({
 
   cjsInterop: true,
   dts: true,
-  entry: ['src/index.ts', 'src/lib/configure-security.ts'],
+  entry: ['src/index.ts', 'src/lib/configure-security.ts', 'src/lib/types.ts'],
   format: ['esm', 'cjs'],
   shims: true,
   silent: !options.watch,


### PR DESCRIPTION
## 🧰 Changes

I believe this is a quirk with `tsup` where default export functions don't play nicely with CJS repositories. This PR slightly shifts things around so all types are stored in a separate file, which is now surfaced in our `exports`.

Before:

<img width="898" alt="CleanShot 2023-09-20 at 18 20 21@2x" src="https://github.com/readmeio/oas-to-har/assets/8854718/19e90f53-8396-48fc-8879-68aa6f410e38">

After:

<img width="1117" alt="CleanShot 2023-09-20 at 18 21 29@2x" src="https://github.com/readmeio/oas-to-har/assets/8854718/f2966e2b-5cfc-4466-9b87-e1dc80657aa3">


## 🧬 QA & Testing

If tests pass and ATTW seems to like these changes, we should be good to go!
