### PR TITLE
revert: bring back old-school lodash

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "@readme/eslint-config",
-    "@readme/eslint-config/typescript"
-  ],
+  "extends": ["@readme/eslint-config", "@readme/eslint-config/typescript"],
   "root": true,
   "rules": {
     // `any` types are fine because we're dealing with a lot of unknown data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@readme/data-urls": "^3.0.0",
         "@readme/oas-extensions": "^20.0.0",
-        "lodash-es": "^4.17.21",
+        "lodash": "^4.17.21",
         "oas": "^21.1.1",
         "qs": "^6.11.2",
         "remove-undefined-objects": "^4.0.1"
@@ -22,7 +22,7 @@
         "@readme/eslint-config": "^12.2.1",
         "@readme/oas-examples": "^5.12.0",
         "@types/har-format": "^1.2.12",
-        "@types/lodash-es": "^4.17.9",
+        "@types/lodash": "^4.14.198",
         "@types/qs": "^6.9.8",
         "@vitest/coverage-v8": "^0.34.4",
         "eslint": "^8.49.0",
@@ -3037,15 +3037,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
       "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
       "dev": true
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.9.tgz",
-      "integrity": "sha512-ZTcmhiI3NNU7dEvWLZJkzG6ao49zOIjEgIE0RgV7wbPxU0f2xT3VSAHw2gmst8swH6V0YkLRGp4qPlX/6I90MQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -10093,11 +10084,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -15563,15 +15549,6 @@
       "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==",
       "dev": true
     },
-    "@types/lodash-es": {
-      "version": "4.17.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.9.tgz",
-      "integrity": "sha512-ZTcmhiI3NNU7dEvWLZJkzG6ao49zOIjEgIE0RgV7wbPxU0f2xT3VSAHw2gmst8swH6V0YkLRGp4qPlX/6I90MQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -20667,11 +20644,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@readme/data-urls": "^3.0.0",
     "@readme/oas-extensions": "^20.0.0",
-    "lodash-es": "^4.17.21",
+    "lodash": "^4.17.21",
     "oas": "^21.1.1",
     "qs": "^6.11.2",
     "remove-undefined-objects": "^4.0.1"
@@ -58,7 +58,7 @@
     "@readme/eslint-config": "^12.2.1",
     "@readme/oas-examples": "^5.12.0",
     "@types/har-format": "^1.2.12",
-    "@types/lodash-es": "^4.17.9",
+    "@types/lodash": "^4.14.198",
     "@types/qs": "^6.9.8",
     "@vitest/coverage-v8": "^0.34.4",
     "eslint": "^8.49.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import type {
 
 import { parse as parseDataUrl } from '@readme/data-urls';
 import { getExtension, PROXY_ENABLED, HEADERS } from '@readme/oas-extensions';
-import { get as lodashGet, set as lodashSet } from 'lodash-es';
+import { get as lodashGet, set as lodashSet } from 'lodash'; // eslint-disable-line no-restricted-imports
 import { Operation, utils } from 'oas';
 import { isRef } from 'oas/rmoas.types';
 import removeUndefinedObjects from 'remove-undefined-objects';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema, SchemaObject } from 'oas/rmoas.types';
 
-import { get as lodashGet } from 'lodash';
+import { get as lodashGet } from 'lodash'; // eslint-disable-line no-restricted-imports
 
 /**
  * Determine if a schema `type` is, or contains, a specific discriminator.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema, SchemaObject } from 'oas/rmoas.types';
 
-import { get as lodashGet } from 'lodash-es';
+import { get as lodashGet } from 'lodash';
 
 /**
  * Determine if a schema `type` is, or contains, a specific discriminator.


### PR DESCRIPTION
| 🚥 Resolves #244 |
| :------------------- |

## 🧰 Changes

Turns out, the fix in #243 was actually the problem and we didn't need #242 at all! So this restores our existing, very bad, `lodash` usage.

## 🧬 QA & Testing

If tests pass we should be good to go! I actually tried `npm link`-ing this repo to the `api` repo and tried it with both CJS and ESM and the results were promising.
