### PR TITLE
fix: try loading `lodash` exports a different way

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,8 @@ import type {
 
 import { parse as parseDataUrl } from '@readme/data-urls';
 import { getExtension, PROXY_ENABLED, HEADERS } from '@readme/oas-extensions';
-import { get as lodashGet, set as lodashSet } from 'lodash'; // eslint-disable-line no-restricted-imports
+import lodashGet from 'lodash/get';
+import lodashSet from 'lodash/set';
 import { Operation, utils } from 'oas';
 import { isRef } from 'oas/rmoas.types';
 import removeUndefinedObjects from 'remove-undefined-objects';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema, SchemaObject } from 'oas/rmoas.types';
 
-import { get as lodashGet } from 'lodash'; // eslint-disable-line no-restricted-imports
+import lodashGet from 'lodash/get';
 
 /**
  * Determine if a schema `type` is, or contains, a specific discriminator.


### PR DESCRIPTION
| 🚥 (hopefully) resolves #244 |
| :------------------- |

## 🧰 Changes

Turns out #245 didn't work 😔 seeing this error now:

<img width="697" alt="CleanShot 2023-09-21 at 14 51 07@2x" src="https://github.com/readmeio/oas-to-har/assets/8854718/d4810fa5-c364-4156-b201-811896bb271c">

this whack-a-mole stuff is exhausting 😮‍💨

## 🧬 QA & Testing

Unfortunately my `npm link` means of testing this has been yielding false-positives, so we won't really know until we publish this 🫠
